### PR TITLE
Fix cloudformation load balancer ouput

### DIFF
--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -21,4 +21,9 @@ class LoadBalancerStack(cdk.Stack):
         self.alb = elbv2.ApplicationLoadBalancer(
             self, "AppLoadBalancer", vpc=vpc, internet_facing=True
         )
-        cdk.CfnOutput(self, "dns", value=self.alb.load_balancer_dns_name)
+        cdk.CfnOutput(
+            self,
+            "LoadBalancerDns",
+            value=self.alb.load_balancer_dns_name,
+            export_name=f"{construct_id}-dns",
+        )


### PR DESCRIPTION
We depend on the cloudformation's load balancer exported DNS endpoint to configure a DNS redirect in organizations-infra repo[1].  The export name needs to be unique in the account.

[1] https://github.com/Sage-Bionetworks-IT/organizations-infra/blob/master/org-formation/800-redirects/_tasks.yaml

