### PR TITLE
Configure Fargate Spot tasks

### DIFF
--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -133,12 +133,12 @@ class ServiceStack(cdk.Stack):
             capacity_provider_strategies=[
                 ecs.CapacityProviderStrategy(
                     capacity_provider="FARGATE",
-                    base=1,       # At least 1 task will be run by FARGATE
+                    base=1,  # At least 1 task will be run by FARGATE
                 ),
                 ecs.CapacityProviderStrategy(
                     capacity_provider="FARGATE_SPOT",
-                    weight=1,     # The remain task will be run by FARGATE_SPOT
-                )
+                    weight=1,  # The remain task will be run by FARGATE_SPOT
+                ),
             ],
         )
 

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -129,6 +129,17 @@ class ServiceStack(cdk.Stack):
                     )
                 ],
             ),
+            # Ensure at least one on demand task and the remaining should be spot tasks
+            capacity_provider_strategies=[
+                ecs.CapacityProviderStrategy(
+                    capacity_provider="FARGATE",
+                    base=1,       # At least 1 task will be run by FARGATE
+                ),
+                ecs.CapacityProviderStrategy(
+                    capacity_provider="FARGATE_SPOT",
+                    weight=1,     # The remain task will be run by FARGATE_SPOT
+                )
+            ],
         )
 
         # Setup AutoScaling policy


### PR DESCRIPTION
To reduce costs we setup ECS to deploy Fargate Spot tasks along with on demand task.  The idea is to ensure that there is at least one fargate on demand task for stability while all other tasks are run with spot tasks for cost efficiency.

AWS cannot do an in place update of this change.  The update requires stacks to be deleted and redeployed.

