### PR TITLE
add agora-admin as codeowner, bump agora-dev version

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @Sage-Bionetworks-IT/sagebio-it @Sage-Bionetworks-IT/infra-oversight-committee
+*  @Sage-Bionetworks-IT/sagebio-it @Sage-Bionetworks-IT/infra-oversight-committee @Sage-Bionetworks-IT/agora-admin

--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ match environment:
 stack_name_prefix = f"agora-{environment}"
 fully_qualified_domain_name = environment_variables["FQDN"]
 environment_tags = environment_variables["TAGS"]
-agora_version = "edge"
+agora_version = "agora/v4.0.0-rc1"
 
 # Define stacks
 cdk_app = cdk.App()


### PR DESCRIPTION
## Description

- Add [Agora-admin team](https://github.com/orgs/Sage-Bionetworks-IT/teams/agora-admin) as CODEOWNER
- Test deploying agora-dev by bumping agora-version