### PR TITLE
Fix agora-dev version

### DIFF
--- a/app.py
+++ b/app.py
@@ -42,7 +42,7 @@ match environment:
 stack_name_prefix = f"agora-{environment}"
 fully_qualified_domain_name = environment_variables["FQDN"]
 environment_tags = environment_variables["TAGS"]
-agora_version = "agora/v4.0.0-rc1"
+agora_version = "4.0.0-rc1"
 
 # Define stacks
 cdk_app = cdk.App()


### PR DESCRIPTION
The previous deployment failed, perhaps because while the git tag includes an `agora/v` prefix ([`agora/v4.0.0-rc1`](https://github.com/Sage-Bionetworks/sage-monorepo/releases/tag/agora%2Fv4.0.0-rc1)), images are tagged with only the version number ([`4.0.0-rc1`](https://github.com/Sage-Bionetworks/sage-monorepo/pkgs/container/agora-apex/336014977?tag=4.0.0-rc1)). This PR updates `agora_version` to match the image tag format.
