### PR TITLE
AG-1591, AG-1592, IT-4241: don't deploy unused containers, create DocumentDB cluster, allow connection from API container

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @Sage-Bionetworks-IT/sagebio-it @Sage-Bionetworks-IT/infra-oversight-committee @Sage-Bionetworks-IT/agora-admin
+*  @Sage-Bionetworks-IT/infra-oversight-committee @Sage-Bionetworks-IT/agora-admin

--- a/app.py
+++ b/app.py
@@ -1,12 +1,15 @@
 from os import environ
 
 import aws_cdk as cdk
+from aws_cdk import aws_ec2 as ec2
 
 from src.ecs_stack import EcsStack
 from src.load_balancer_stack import LoadBalancerStack
 from src.network_stack import NetworkStack
 from src.service_props import ServiceProps, ServiceSecret
 from src.service_stack import LoadBalancedServiceStack, ServiceStack
+from src.docdb_props import DocdbProps
+from src.docdb_stack import DocdbStack
 
 # get the environment and set environment specific variables
 VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
@@ -43,6 +46,7 @@ stack_name_prefix = f"agora-{environment}"
 fully_qualified_domain_name = environment_variables["FQDN"]
 environment_tags = environment_variables["TAGS"]
 agora_version = "4.0.0-rc1"
+docdb_master_username = "master"
 
 # Define stacks
 cdk_app = cdk.App()
@@ -56,6 +60,19 @@ network_stack = NetworkStack(
     scope=cdk_app,
     construct_id=f"{stack_name_prefix}-network",
     vpc_cidr=environment_variables["VPC_CIDR"],
+)
+
+docdb_props = DocdbProps(
+    instance_type=ec2.InstanceType.of(
+        ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE
+    ),
+    master_username=docdb_master_username,
+)
+docdb_stack = DocdbStack(
+    scope=cdk_app,
+    construct_id=f"{stack_name_prefix}-docdb",
+    vpc=network_stack.vpc,
+    props=docdb_props,
 )
 
 ecs_stack = EcsStack(
@@ -84,21 +101,16 @@ api_props = ServiceProps(
         "NODE_ENV": "development",
         "MONGODB_PORT": "27017",
         "MONGODB_NAME": "agora",
+        "MONDODB_USER": docdb_master_username,
+        "MONGODB_HOST": docdb_stack.cluster.cluster_endpoint.hostname,
     },
     container_secrets=[
         ServiceSecret(
-            secret_name=f"{stack_name_prefix}/MongodbUsername",
-            environment_key="MONGODB_USER",
-        ),
-        ServiceSecret(
-            secret_name=f"{stack_name_prefix}/MongodbPassword",
+            secret_name=docdb_stack.master_password_secret.secret_name,
             environment_key="MONGODB_PASS",
-        ),
-        ServiceSecret(
-            secret_name=f"{stack_name_prefix}/MongodbHost",
-            environment_key="MONGODB_HOST",
-        ),
+        )
     ],
+    container_security_groups=[docdb_stack.access_docdb_security_group],
 )
 api_stack = ServiceStack(
     scope=cdk_app,
@@ -107,6 +119,7 @@ api_stack = ServiceStack(
     cluster=ecs_stack.cluster,
     props=api_props,
 )
+api_stack.add_dependency(docdb_stack)
 
 app_props = ServiceProps(
     container_name="agora-app",
@@ -118,7 +131,6 @@ app_props = ServiceProps(
         "APP_VERSION": f"{agora_version}",
         "CSR_API_URL": f"http://{fully_qualified_domain_name}/api/v1",
         "SSR_API_URL": "http://agora-api:3333/v1",
-        "ROLLBAR_TOKEN": "e788198867474855a996485580b08d03",
         "TAG_NAME": f"agora/v${agora_version}",
     },
 )

--- a/app.py
+++ b/app.py
@@ -75,73 +75,6 @@ load_balancer_stack = LoadBalancerStack(
     vpc=network_stack.vpc,
 )
 
-api_docs_props = ServiceProps(
-    container_name="agora-api-docs",
-    container_location=f"ghcr.io/sage-bionetworks/agora-api-docs:{agora_version}",
-    container_port=8010,
-    container_memory=200,
-    container_env_vars={"PORT": "8010"},
-)
-api_docs_stack = ServiceStack(
-    scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-api-docs",
-    vpc=network_stack.vpc,
-    cluster=ecs_stack.cluster,
-    props=api_docs_props,
-)
-
-mongo_props = ServiceProps(
-    container_name="agora-mongo",
-    container_location=f"ghcr.io/sage-bionetworks/agora-mongo:{agora_version}",
-    container_port=27017,
-    container_memory=500,
-    container_env_vars={
-        "MONGO_INITDB_ROOT_USERNAME": "root",
-        "MONGO_INITDB_ROOT_PASSWORD": "changeme",
-        "MONGO_INITDB_DATABASE": "agora",
-    },
-    container_volumes=[
-        ContainerVolume(
-            path="/data/db",
-            size=30,
-        )
-    ],
-)
-mongo_stack = ServiceStack(
-    scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-mongo",
-    vpc=network_stack.vpc,
-    cluster=ecs_stack.cluster,
-    props=mongo_props,
-)
-
-# It is probably not appropriate host this container in ECS
-# data_props = ServiceProps(
-#     container_name="agora-data",
-#     container_location=f"ghcr.io/sage-bionetworks/agora-data:{agora_version}",
-#     container_port=9999,  # Not used
-#     container_memory=2048,
-# )
-# data_stack = ServiceStack(
-#     scope=cdk_app,
-#     construct_id=f"{stack_name_prefix}-data",
-#     vpc=network_stack.vpc,
-#     cluster=ecs_stack.cluster,
-#     props=data_props,
-#     container_env_vars={
-#         "DB_USER": "root",
-#         "DB_PASS": "changeme",
-#         "DB_NAME": "agora",
-#         "DB_PORT": "27017",
-#         "DB_HOST": "agora-mongo",
-#         "DATA_FILE": "syn13363290",
-#         "DATA_VERSION": "68",
-#         "TEAM_IMAGES_ID": "syn12861877",
-#         "SYNAPSE_AUTH_TOKEN": "agora-service-user-pat-here",
-#     },
-# )
-# data_stack.add_dependency(mongo_stack)
-
 api_props = ServiceProps(
     container_name="agora-api",
     container_location=f"ghcr.io/sage-bionetworks/agora-api:{agora_version}",
@@ -174,7 +107,6 @@ api_stack = ServiceStack(
     cluster=ecs_stack.cluster,
     props=api_props,
 )
-api_stack.add_dependency(mongo_stack)
 
 app_props = ServiceProps(
     container_name="agora-app",
@@ -222,7 +154,6 @@ apex_stack = LoadBalancedServiceStack(
     health_check_path="/health",
 )
 apex_stack.add_dependency(app_stack)
-apex_stack.add_dependency(api_docs_stack)
 apex_stack.add_dependency(api_stack)
 
 cdk_app.synth()

--- a/app.py
+++ b/app.py
@@ -127,10 +127,10 @@ app_props = ServiceProps(
     container_port=4200,
     container_memory=200,
     container_env_vars={
-        "API_DOCS_URL": f"http://{fully_qualified_domain_name}/api-docs",
+        "API_DOCS_URL": f"https://{fully_qualified_domain_name}/api-docs",
         "APP_VERSION": f"{agora_version}",
-        "CSR_API_URL": f"http://{fully_qualified_domain_name}/api/v1",
-        "SSR_API_URL": "http://agora-api:3333/v1",
+        "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
+        "SSR_API_URL": "https://agora-api:3333/v1",
         "TAG_NAME": f"agora/v${agora_version}",
     },
 )

--- a/app.py
+++ b/app.py
@@ -47,6 +47,7 @@ fully_qualified_domain_name = environment_variables["FQDN"]
 environment_tags = environment_variables["TAGS"]
 agora_version = "4.0.0-rc1"
 docdb_master_username = "master"
+mongodb_port = 27017
 
 # Define stacks
 cdk_app = cdk.App()
@@ -67,6 +68,7 @@ docdb_props = DocdbProps(
         ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE
     ),
     master_username=docdb_master_username,
+    port=mongodb_port,
 )
 docdb_stack = DocdbStack(
     scope=cdk_app,
@@ -99,7 +101,7 @@ api_props = ServiceProps(
     container_memory=1024,
     container_env_vars={
         "NODE_ENV": "development",
-        "MONGODB_PORT": "27017",
+        "MONGODB_PORT": f"{mongodb_port}",
         "MONGODB_NAME": "agora",
         "MONDODB_USER": docdb_master_username,
         "MONGODB_HOST": docdb_stack.cluster.cluster_endpoint.hostname,
@@ -110,7 +112,6 @@ api_props = ServiceProps(
             environment_key="MONGODB_PASS",
         )
     ],
-    container_security_groups=[docdb_stack.access_docdb_security_group],
 )
 api_stack = ServiceStack(
     scope=cdk_app,
@@ -120,6 +121,10 @@ api_stack = ServiceStack(
     props=api_props,
 )
 api_stack.add_dependency(docdb_stack)
+api_stack.service.connections.allow_to_default_port(
+    docdb_stack.cluster,
+    "Allow API container to connect to DocumentDB cluster",
+)
 
 app_props = ServiceProps(
     container_name="agora-app",

--- a/app.py
+++ b/app.py
@@ -118,6 +118,8 @@ app_props = ServiceProps(
         "APP_VERSION": f"{agora_version}",
         "CSR_API_URL": f"http://{fully_qualified_domain_name}/api/v1",
         "SSR_API_URL": "http://agora-api:3333/v1",
+        "ROLLBAR_TOKEN"="e788198867474855a996485580b08d03"
+        "TAG_NAME"=f"agora/v${agora_version}"
     },
 )
 app_stack = ServiceStack(

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import aws_cdk as cdk
 from src.ecs_stack import EcsStack
 from src.load_balancer_stack import LoadBalancerStack
 from src.network_stack import NetworkStack
-from src.service_props import ServiceProps, ContainerVolume
+from src.service_props import ServiceProps, ContainerVolume, ServiceSecret
 from src.service_stack import LoadBalancedServiceStack, ServiceStack
 
 # get the environment and set environment specific variables
@@ -148,9 +148,24 @@ api_props = ServiceProps(
     container_port=3333,
     container_memory=1024,
     container_env_vars={
-        "MONGODB_URI": "mongodb://root:changeme@agora-mongo:27017/agora?authSource=admin",
-        "NODE_ENV": "development",
+        "NODE_ENV": "development"
+        "MONGODB_PORT": "27017",
+        "MONGODB_NAME": "agora"
     },
+    container_secrets=[
+        ServiceSecret(
+            secret_name=f"{stack_name_prefix}/MongodbUsername",
+            environment_key="MONGODB_USER",
+        ),
+        ServiceSecret(
+            secret_name=f"{stack_name_prefix}/MongodbPassword",
+            environment_key="MONGODB_PASS",
+        ),
+        ServiceSecret(
+            secret_name=f"{stack_name_prefix}/MongodbHost",
+            environment_key="MONGODB_HOST",
+        ),
+    ]
 )
 api_stack = ServiceStack(
     scope=cdk_app,

--- a/app.py
+++ b/app.py
@@ -132,10 +132,10 @@ app_props = ServiceProps(
     container_port=4200,
     container_memory=200,
     container_env_vars={
-        "API_DOCS_URL": f"https://{fully_qualified_domain_name}/api-docs",
+        "API_DOCS_URL": f"http://{fully_qualified_domain_name}/api-docs",
         "APP_VERSION": f"{agora_version}",
-        "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
-        "SSR_API_URL": "https://agora-api:3333/v1",
+        "CSR_API_URL": f"http://{fully_qualified_domain_name}/api/v1",
+        "SSR_API_URL": "http://agora-api:3333/v1",
         "TAG_NAME": f"agora/v${agora_version}",
     },
 )

--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ import aws_cdk as cdk
 from src.ecs_stack import EcsStack
 from src.load_balancer_stack import LoadBalancerStack
 from src.network_stack import NetworkStack
-from src.service_props import ServiceProps, ContainerVolume, ServiceSecret
+from src.service_props import ServiceProps, ServiceSecret
 from src.service_stack import LoadBalancedServiceStack, ServiceStack
 
 # get the environment and set environment specific variables
@@ -81,9 +81,9 @@ api_props = ServiceProps(
     container_port=3333,
     container_memory=1024,
     container_env_vars={
-        "NODE_ENV": "development"
+        "NODE_ENV": "development",
         "MONGODB_PORT": "27017",
-        "MONGODB_NAME": "agora"
+        "MONGODB_NAME": "agora",
     },
     container_secrets=[
         ServiceSecret(
@@ -98,7 +98,7 @@ api_props = ServiceProps(
             secret_name=f"{stack_name_prefix}/MongodbHost",
             environment_key="MONGODB_HOST",
         ),
-    ]
+    ],
 )
 api_stack = ServiceStack(
     scope=cdk_app,
@@ -118,8 +118,8 @@ app_props = ServiceProps(
         "APP_VERSION": f"{agora_version}",
         "CSR_API_URL": f"http://{fully_qualified_domain_name}/api/v1",
         "SSR_API_URL": "http://agora-api:3333/v1",
-        "ROLLBAR_TOKEN"="e788198867474855a996485580b08d03"
-        "TAG_NAME"=f"agora/v${agora_version}"
+        "ROLLBAR_TOKEN": "e788198867474855a996485580b08d03",
+        "TAG_NAME": f"agora/v${agora_version}",
     },
 )
 app_stack = ServiceStack(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-aws-cdk-lib~=2.139
+aws-cdk-lib~=2.176
 constructs~=10.0
 boto3~=1.34

--- a/src/docdb_props.py
+++ b/src/docdb_props.py
@@ -7,8 +7,12 @@ class DocdbProps:
 
     instance_type: What type of instance to start for the replicas
     master_username: The database admin account username
+    port: The MongoDB port
     """
 
-    def __init__(self, instance_type: ec2.InstanceType, master_username: str) -> None:
+    def __init__(
+        self, instance_type: ec2.InstanceType, master_username: str, port: int
+    ) -> None:
         self.instance_type = instance_type
         self.master_username = master_username
+        self.port = port

--- a/src/docdb_props.py
+++ b/src/docdb_props.py
@@ -1,0 +1,14 @@
+from aws_cdk import aws_ec2 as ec2
+
+
+class DocdbProps:
+    """
+    DocumentDB properties
+
+    instance_type: What type of instance to start for the replicas
+    master_username: The database admin account username
+    """
+
+    def __init__(self, instance_type: ec2.InstanceType, master_username: str) -> None:
+        self.instance_type = instance_type
+        self.master_username = master_username

--- a/src/docdb_stack.py
+++ b/src/docdb_stack.py
@@ -8,6 +8,8 @@ from src.docdb_props import DocdbProps
 
 from constructs import Construct
 
+MONGODB_PORT = 27017
+
 
 class DocdbStack(cdk.Stack):
     """
@@ -26,7 +28,7 @@ class DocdbStack(cdk.Stack):
 
         self.master_password_secret = sm.Secret(
             self,
-            f"{construct_id}-master-password",
+            "DocDbMasterPassword",
             generate_secret_string=sm.SecretStringGenerator(
                 password_length=32, exclude_punctuation=True
             ),
@@ -34,19 +36,19 @@ class DocdbStack(cdk.Stack):
 
         self.access_docdb_security_group = ec2.SecurityGroup(
             self,
-            f"{construct_id}-access-docdb-sg",
+            "DocDbAccessSecurityGroup",
             vpc=vpc,
             description="Instances with access to document DB servers",
         )
         self.docdb_security_group = ec2.SecurityGroup(
             self,
-            f"{construct_id}-docdb-sg",
+            "DocDbSecurityGroup",
             vpc=vpc,
             description="Document DB server management and access ports",
         )
         self.docdb_security_group.add_ingress_rule(
             peer=self.access_docdb_security_group,
-            connection=ec2.Port.tcp_range(27017, 27030),
+            connection=ec2.Port.tcp_range(MONGODB_PORT, 27030),
         )
         self.docdb_security_group.add_ingress_rule(
             peer=self.access_docdb_security_group, connection=ec2.Port.tcp(28017)
@@ -54,10 +56,9 @@ class DocdbStack(cdk.Stack):
 
         cluster_parameter_group = docdb.ClusterParameterGroup(
             self,
-            "ClusterParameterGroup",
+            "DocDbClusterParameterGroup",
             family="docdb5.0",
             parameters={
-                "audit_logs": "disabled",
                 "audit_logs": "disabled",
                 "profiler": "enabled",
                 "profiler_sampling_rate": "1.0",
@@ -66,13 +67,12 @@ class DocdbStack(cdk.Stack):
                 "tls": "disabled",
                 "ttl_monitor": "disabled",
             },
-            db_cluster_parameter_group_name=f"{construct_id}-cluster-parameter-group",
         )
 
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_docdb/DatabaseCluster.html
         self.cluster = docdb.DatabaseCluster(
             self,
-            "Database",
+            "DocDbCluster",
             master_user=docdb.Login(
                 username=props.master_username,
                 password=self.master_password_secret.secret_value,
@@ -86,7 +86,7 @@ class DocdbStack(cdk.Stack):
             removal_policy=cdk.RemovalPolicy.DESTROY,
             storage_encrypted=True,
             preferred_maintenance_window="sat:06:54-sat:07:24",
-            port=27017,
+            port=MONGODB_PORT,
             export_profiler_logs_to_cloud_watch=True,
             security_group=self.docdb_security_group,
         )

--- a/src/docdb_stack.py
+++ b/src/docdb_stack.py
@@ -1,0 +1,94 @@
+import aws_cdk as cdk
+from aws_cdk import (
+    aws_docdb as docdb,
+    aws_ec2 as ec2,
+    aws_secretsmanager as sm,
+)
+from src.docdb_props import DocdbProps
+
+from constructs import Construct
+
+
+class DocdbStack(cdk.Stack):
+    """
+    DocumentDB cluster
+    """
+
+    def __init__(
+        self,
+        scope: Construct,
+        construct_id: str,
+        vpc: ec2.Vpc,
+        props: DocdbProps,
+        **kwargs,
+    ) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        self.master_password_secret = sm.Secret(
+            self,
+            f"{construct_id}-master-password",
+            generate_secret_string=sm.SecretStringGenerator(
+                password_length=32, exclude_punctuation=True
+            ),
+        )
+
+        self.access_docdb_security_group = ec2.SecurityGroup(
+            self,
+            f"{construct_id}-access-docdb-sg",
+            vpc=vpc,
+            description="Instances with access to document DB servers",
+        )
+        self.docdb_security_group = ec2.SecurityGroup(
+            self,
+            f"{construct_id}-docdb-sg",
+            vpc=vpc,
+            description="Document DB server management and access ports",
+        )
+        self.docdb_security_group.add_ingress_rule(
+            peer=self.access_docdb_security_group,
+            connection=ec2.Port.tcp_range(27017, 27030),
+        )
+        self.docdb_security_group.add_ingress_rule(
+            peer=self.access_docdb_security_group, connection=ec2.Port.tcp(28017)
+        )
+
+        cluster_parameter_group = docdb.ClusterParameterGroup(
+            self,
+            "ClusterParameterGroup",
+            family="docdb5.0",
+            parameters={
+                "audit_logs": "disabled",
+                "audit_logs": "disabled",
+                "profiler": "enabled",
+                "profiler_sampling_rate": "1.0",
+                "profiler_threshold_ms": "50",
+                "change_stream_log_retention_duration": "10800",
+                "tls": "disabled",
+                "ttl_monitor": "disabled",
+            },
+            db_cluster_parameter_group_name=f"{construct_id}-cluster-parameter-group",
+        )
+
+        # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_docdb/DatabaseCluster.html
+        self.cluster = docdb.DatabaseCluster(
+            self,
+            "Database",
+            master_user=docdb.Login(
+                username=props.master_username,
+                password=self.master_password_secret.secret_value,
+            ),
+            instance_type=props.instance_type,
+            vpc=vpc,
+            vpc_subnets=ec2.SubnetSelection(
+                subnet_type=ec2.SubnetType.PRIVATE_WITH_EGRESS
+            ),
+            parameter_group=cluster_parameter_group,
+            removal_policy=cdk.RemovalPolicy.DESTROY,
+            storage_encrypted=True,
+            preferred_maintenance_window="sat:06:54-sat:07:24",
+            port=27017,
+            export_profiler_logs_to_cloud_watch=True,
+            security_group=self.docdb_security_group,
+        )
+
+        self.cluster.add_security_groups(self.access_docdb_security_group)

--- a/src/docdb_stack.py
+++ b/src/docdb_stack.py
@@ -8,8 +8,6 @@ from src.docdb_props import DocdbProps
 
 from constructs import Construct
 
-MONGODB_PORT = 27017
-
 
 class DocdbStack(cdk.Stack):
     """
@@ -32,26 +30,6 @@ class DocdbStack(cdk.Stack):
             generate_secret_string=sm.SecretStringGenerator(
                 password_length=32, exclude_punctuation=True
             ),
-        )
-
-        self.access_docdb_security_group = ec2.SecurityGroup(
-            self,
-            "DocDbAccessSecurityGroup",
-            vpc=vpc,
-            description="Instances with access to document DB servers",
-        )
-        self.docdb_security_group = ec2.SecurityGroup(
-            self,
-            "DocDbSecurityGroup",
-            vpc=vpc,
-            description="Document DB server management and access ports",
-        )
-        self.docdb_security_group.add_ingress_rule(
-            peer=self.access_docdb_security_group,
-            connection=ec2.Port.tcp_range(MONGODB_PORT, 27030),
-        )
-        self.docdb_security_group.add_ingress_rule(
-            peer=self.access_docdb_security_group, connection=ec2.Port.tcp(28017)
         )
 
         cluster_parameter_group = docdb.ClusterParameterGroup(
@@ -86,9 +64,6 @@ class DocdbStack(cdk.Stack):
             removal_policy=cdk.RemovalPolicy.DESTROY,
             storage_encrypted=True,
             preferred_maintenance_window="sat:06:54-sat:07:24",
-            port=MONGODB_PORT,
+            port=props.port,
             export_profiler_logs_to_cloud_watch=True,
-            security_group=self.docdb_security_group,
         )
-
-        self.cluster.add_security_groups(self.access_docdb_security_group)

--- a/src/service_props.py
+++ b/src/service_props.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
-from aws_cdk import aws_ecs as ecs, aws_ec2 as ec2
+from aws_cdk import aws_ecs as ecs
 
 CONTAINER_LOCATION_PATH_ID = "path://"
 
@@ -62,7 +62,6 @@ class ServiceProps:
     auto_scale_max_capacity: the fargate auto scaling maximum capacity
     container_command: Optional commands to run during the container startup
     container_healthcheck: Optional health check configuration for the container
-    container_security_groups: Optional List of security groups for the container
     """
 
     def __init__(
@@ -78,7 +77,6 @@ class ServiceProps:
         auto_scale_max_capacity: int = 1,
         container_command: Optional[Sequence[str]] = None,
         container_healthcheck: Optional[ecs.HealthCheck] = None,
-        container_security_groups: Optional[List[ec2.SecurityGroup]] = None,
     ) -> None:
         self.container_name = container_name
         self.container_port = container_port
@@ -108,8 +106,3 @@ class ServiceProps:
         self.auto_scale_max_capacity = auto_scale_max_capacity
         self.container_command = container_command
         self.container_healthcheck = container_healthcheck
-
-        if container_security_groups is None:
-            self.container_security_groups = []
-        else:
-            self.container_security_groups = container_security_groups

--- a/src/service_props.py
+++ b/src/service_props.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import List, Optional, Sequence
 
-from aws_cdk import aws_ecs as ecs
+from aws_cdk import aws_ecs as ecs, aws_ec2 as ec2
 
 CONTAINER_LOCATION_PATH_ID = "path://"
 
@@ -62,6 +62,7 @@ class ServiceProps:
     auto_scale_max_capacity: the fargate auto scaling maximum capacity
     container_command: Optional commands to run during the container startup
     container_healthcheck: Optional health check configuration for the container
+    container_security_groups: Optional List of security groups for the container
     """
 
     def __init__(
@@ -77,6 +78,7 @@ class ServiceProps:
         auto_scale_max_capacity: int = 1,
         container_command: Optional[Sequence[str]] = None,
         container_healthcheck: Optional[ecs.HealthCheck] = None,
+        container_security_groups: Optional[List[ec2.SecurityGroup]] = None,
     ) -> None:
         self.container_name = container_name
         self.container_port = container_port
@@ -106,3 +108,8 @@ class ServiceProps:
         self.auto_scale_max_capacity = auto_scale_max_capacity
         self.container_command = container_command
         self.container_healthcheck = container_healthcheck
+
+        if container_security_groups is None:
+            self.container_security_groups = []
+        else:
+            self.container_security_groups = container_security_groups

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -132,6 +132,8 @@ class ServiceStack(cdk.Stack):
             peer=ec2.Peer.ipv4("0.0.0.0/0"),
             connection=ec2.Port.tcp(props.container_port),
         )
+        self.security_groups = props.container_security_groups.copy()
+        self.security_groups.append(self.security_group)
 
         # attach ECS task to ECS cluster
         self.service = ecs.FargateService(
@@ -141,7 +143,7 @@ class ServiceStack(cdk.Stack):
             task_definition=self.task_definition,
             enable_execute_command=True,
             circuit_breaker=ecs.DeploymentCircuitBreaker(enable=True, rollback=True),
-            security_groups=([self.security_group]),
+            security_groups=self.security_groups,
             service_connect_configuration=ecs.ServiceConnectProps(
                 log_driver=ecs.LogDrivers.aws_logs(stream_prefix=f"{construct_id}"),
                 services=[

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -127,14 +127,6 @@ class ServiceStack(cdk.Stack):
             health_check=props.container_healthcheck,
         )
 
-        self.security_group = ec2.SecurityGroup(self, "SecurityGroup", vpc=vpc)
-        self.security_group.add_ingress_rule(
-            peer=ec2.Peer.ipv4("0.0.0.0/0"),
-            connection=ec2.Port.tcp(props.container_port),
-        )
-        self.security_groups = props.container_security_groups.copy()
-        self.security_groups.append(self.security_group)
-
         # attach ECS task to ECS cluster
         self.service = ecs.FargateService(
             self,
@@ -143,7 +135,6 @@ class ServiceStack(cdk.Stack):
             task_definition=self.task_definition,
             enable_execute_command=True,
             circuit_breaker=ecs.DeploymentCircuitBreaker(enable=True, rollback=True),
-            security_groups=self.security_groups,
             service_connect_configuration=ecs.ServiceConnectProps(
                 log_driver=ecs.LogDrivers.aws_logs(stream_prefix=f"{construct_id}"),
                 services=[
@@ -166,6 +157,7 @@ class ServiceStack(cdk.Stack):
                 ),
             ],
         )
+        self.service.connections.allow_from_any_ipv4(ec2.Port.tcp(props.container_port))
 
         # Setup AutoScaling policy
         scaling = self.service.auto_scale_task_count(

--- a/tests/unit/test_docdb_stack.py
+++ b/tests/unit/test_docdb_stack.py
@@ -1,0 +1,62 @@
+import aws_cdk as cdk
+from aws_cdk import aws_ec2 as ec2, assertions as assertions
+
+from src.network_stack import NetworkStack
+from src.docdb_stack import DocdbStack
+from src.docdb_props import DocdbProps
+
+
+def test_docdb_created():
+    cdk_app = cdk.App()
+    master_username = "myuser"
+    vpc_cidr = "10.254.192.0/24"
+    network_stack = NetworkStack(cdk_app, "NetworkStack", vpc_cidr=vpc_cidr)
+
+    docdb_props = DocdbProps(
+        instance_type=ec2.InstanceType.of(
+            ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE
+        ),
+        master_username=master_username,
+    )
+    docdb_stack = DocdbStack(
+        scope=cdk_app,
+        construct_id="docdb",
+        vpc=network_stack.vpc,
+        props=docdb_props,
+    )
+
+    template = assertions.Template.from_stack(docdb_stack)
+    template.has_resource_properties(
+        "AWS::DocDB::DBClusterParameterGroup",
+        {
+            "Parameters": {
+                "audit_logs": "disabled",
+                "profiler": "enabled",
+                "profiler_sampling_rate": "1.0",
+                "profiler_threshold_ms": "50",
+                "change_stream_log_retention_duration": "10800",
+                "tls": "disabled",
+                "ttl_monitor": "disabled",
+            }
+        },
+    )
+    template.has_resource_properties(
+        "AWS::DocDB::DBCluster",
+        {
+            "MasterUsername": master_username,
+            "MasterUserPassword": assertions.Match.any_value(),
+            "DBSubnetGroupName": assertions.Match.any_value(),
+            "DBClusterParameterGroupName": assertions.Match.any_value(),
+            "StorageEncrypted": True,
+            "PreferredMaintenanceWindow": "sat:06:54-sat:07:24",
+            "Port": 27017,
+            "EnableCloudwatchLogsExports": ["profiler"],
+            "VpcSecurityGroupIds": [
+                assertions.Match.any_value(),
+                assertions.Match.any_value(),
+            ],
+        },
+    )
+    template.resource_properties_count_is(
+        "AWS::EC2::SecurityGroup", assertions.Match.any_value(), 2
+    )

--- a/tests/unit/test_docdb_stack.py
+++ b/tests/unit/test_docdb_stack.py
@@ -9,6 +9,7 @@ from src.docdb_props import DocdbProps
 def test_docdb_created():
     cdk_app = cdk.App()
     master_username = "myuser"
+    port = 27017
     vpc_cidr = "10.254.192.0/24"
     network_stack = NetworkStack(cdk_app, "NetworkStack", vpc_cidr=vpc_cidr)
 
@@ -17,6 +18,7 @@ def test_docdb_created():
             ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE
         ),
         master_username=master_username,
+        port=port,
     )
     docdb_stack = DocdbStack(
         scope=cdk_app,
@@ -49,14 +51,13 @@ def test_docdb_created():
             "DBClusterParameterGroupName": assertions.Match.any_value(),
             "StorageEncrypted": True,
             "PreferredMaintenanceWindow": "sat:06:54-sat:07:24",
-            "Port": 27017,
+            "Port": port,
             "EnableCloudwatchLogsExports": ["profiler"],
             "VpcSecurityGroupIds": [
-                assertions.Match.any_value(),
                 assertions.Match.any_value(),
             ],
         },
     )
     template.resource_properties_count_is(
-        "AWS::EC2::SecurityGroup", assertions.Match.any_value(), 2
+        "AWS::EC2::SecurityGroup", assertions.Match.any_value(), 1
     )

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 
 # Install Node.js dependencies
-npm install -g aws-cdk@2.151.0
+npm install -g aws-cdk@2.176.0
 
 # Install Python dependencies
 python -m venv .venv


### PR DESCRIPTION
## Description

- [AG-1591](https://sagebionetworks.jira.com/browse/AG-1591): don't deploy unused containers (agora-mongo, agora-data, agora-api-docs)
- [IT-4241](https://sagebionetworks.jira.com/browse/IT-4241): create DocumentDB cluster
- [AG-1592](https://sagebionetworks.jira.com/browse/AG-1592): add secrets to connect to DocumentDB instance
- Add missing agora-app environment variables
- Update CODEOWNERS [per Khai](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/pull/15#discussion_r1915286795)

Depends on https://github.com/Sage-Bionetworks/sage-monorepo/pull/2967

Note: plan to add the bastion in a future PR, work tracked in [IT-4243](https://sagebionetworks.jira.com/browse/IT-4243)

[AG-1591]: https://sagebionetworks.jira.com/browse/AG-1591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1592]: https://sagebionetworks.jira.com/browse/AG-1592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IT-4241]: https://sagebionetworks.jira.com/browse/IT-4241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[IT-4243]: https://sagebionetworks.jira.com/browse/IT-4243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ