### PR TITLE
IT-4243: fix region lookup

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -51,4 +51,3 @@ jobs:
         run: cdk deploy --all --concurrency 5 --require-approval never
         env:
           ENV: ${{ inputs.environment }}
-          REGION: ${{ inputs.aws-region }}

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -51,3 +51,4 @@ jobs:
         run: cdk deploy --all --concurrency 5 --require-approval never
         env:
           ENV: ${{ inputs.environment }}
+          REGION: ${{ inputs.aws-region }}

--- a/app.py
+++ b/app.py
@@ -16,9 +16,6 @@ from src.bastion_stack import BastionStack
 # get the environment and set environment specific variables
 VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
 environment = environ.get("ENV")
-account = environ.get("CDK_DEPLOY_ACCOUNT") or environ.get(
-    "CDK_DEFAULT_ACCOUNT", "012345678901"
-)
 match environment:
     case "prod":
         environment_variables = {
@@ -178,7 +175,6 @@ apex_stack = LoadBalancedServiceStack(
     cluster=ecs_stack.cluster,
     props=apex_props,
     load_balancer=load_balancer_stack.alb,
-    certificate_account_id=account,
     certificate_resource_id=environment_variables["CERTIFICATE_RESOURCE_ID"],
     health_check_path="/health",
 )

--- a/app.py
+++ b/app.py
@@ -13,14 +13,10 @@ from src.docdb_stack import DocdbStack
 from src.bastion_props import BastionProps
 from src.bastion_stack import BastionStack
 
-# get the region, or use a default
-region = environ.get("REGION")
-if region is None:
-    region = "us-east-1"
-
 # get the environment and set environment specific variables
 VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
 environment = environ.get("ENV")
+region = environ.get("AWS_REGION")
 match environment:
     case "prod":
         environment_variables = {

--- a/app.py
+++ b/app.py
@@ -16,27 +16,29 @@ from src.bastion_stack import BastionStack
 # get the environment and set environment specific variables
 VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
 environment = environ.get("ENV")
-region = environ.get("AWS_REGION")
 match environment:
     case "prod":
         environment_variables = {
             "VPC_CIDR": "10.254.174.0/24",
             "FQDN": "prod.agora.io",
-            "CERTIFICATE_ARN": f"arn:aws:acm:{region}:681175625864:certificate/69b3ba97-b382-4648-8f94-a250b77b4994",
+            "CERTIFICATE_ACCOUNT_ID": "681175625864",
+            "CERTIFICATE_RESOURCE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
     case "stage":
         environment_variables = {
             "VPC_CIDR": "10.254.173.0/24",
             "FQDN": "stage.agora.io",
-            "CERTIFICATE_ARN": f"arn:aws:acm:{region}:681175625864:certificate/69b3ba97-b382-4648-8f94-a250b77b4994",
+            "CERTIFICATE_ACCOUNT_ID": "681175625864",
+            "CERTIFICATE_RESOURCE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
     case "dev":
         environment_variables = {
             "VPC_CIDR": "10.254.172.0/24",
             "FQDN": "dev.agora.io",
-            "CERTIFICATE_ARN": f"arn:aws:acm:{region}:607346494281:certificate/e8093404-7db1-4042-90d0-01eb5bde1ffc",
+            "CERTIFICATE_ACCOUNT_ID": "607346494281",
+            "CERTIFICATE_RESOURCE_ID": "e8093404-7db1-4042-90d0-01eb5bde1ffc",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
     case _:
@@ -176,7 +178,8 @@ apex_stack = LoadBalancedServiceStack(
     cluster=ecs_stack.cluster,
     props=apex_props,
     load_balancer=load_balancer_stack.alb,
-    certificate_arn=environment_variables["CERTIFICATE_ARN"],
+    certificate_account_id=environment_variables["CERTIFICATE_ACCOUNT_ID"],
+    certificate_resource_id=environment_variables["CERTIFICATE_RESOURCE_ID"],
     health_check_path="/health",
 )
 apex_stack.add_dependency(app_stack)
@@ -186,7 +189,6 @@ bastion_props = BastionProps(
     key_name="agora-ci",
     instance_type=ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
     ami_id="ami-074a6fac5773fe883",
-    ami_region=region,
 )
 bastion_stack = BastionStack(
     scope=cdk_app,

--- a/app.py
+++ b/app.py
@@ -16,12 +16,14 @@ from src.bastion_stack import BastionStack
 # get the environment and set environment specific variables
 VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
 environment = environ.get("ENV")
+account = environ.get("CDK_DEPLOY_ACCOUNT") or environ.get(
+    "CDK_DEFAULT_ACCOUNT", "012345678901"
+)
 match environment:
     case "prod":
         environment_variables = {
             "VPC_CIDR": "10.254.174.0/24",
             "FQDN": "prod.agora.io",
-            "CERTIFICATE_ACCOUNT_ID": "681175625864",
             "CERTIFICATE_RESOURCE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
@@ -29,7 +31,6 @@ match environment:
         environment_variables = {
             "VPC_CIDR": "10.254.173.0/24",
             "FQDN": "stage.agora.io",
-            "CERTIFICATE_ACCOUNT_ID": "681175625864",
             "CERTIFICATE_RESOURCE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
@@ -37,7 +38,6 @@ match environment:
         environment_variables = {
             "VPC_CIDR": "10.254.172.0/24",
             "FQDN": "dev.agora.io",
-            "CERTIFICATE_ACCOUNT_ID": "607346494281",
             "CERTIFICATE_RESOURCE_ID": "e8093404-7db1-4042-90d0-01eb5bde1ffc",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
@@ -178,7 +178,7 @@ apex_stack = LoadBalancedServiceStack(
     cluster=ecs_stack.cluster,
     props=apex_props,
     load_balancer=load_balancer_stack.alb,
-    certificate_account_id=environment_variables["CERTIFICATE_ACCOUNT_ID"],
+    certificate_account_id=account,
     certificate_resource_id=environment_variables["CERTIFICATE_RESOURCE_ID"],
     health_check_path="/health",
 )

--- a/app.py
+++ b/app.py
@@ -13,13 +13,14 @@ from src.docdb_stack import DocdbStack
 from src.bastion_props import BastionProps
 from src.bastion_stack import BastionStack
 
-# Define stacks
-cdk_app = cdk.App()
+# get the region, or use a default
+region = environ.get("REGION")
+if region is None:
+    region = "us-east-1"
 
 # get the environment and set environment specific variables
 VALID_ENVIRONMENTS = ["dev", "stage", "prod"]
 environment = environ.get("ENV")
-region = cdk_app.region
 match environment:
     case "prod":
         environment_variables = {
@@ -55,6 +56,9 @@ agora_version = "4.0.0-rc1"
 docdb_master_username = "master"
 mongodb_port = 27017
 vpn_cidr = "10.1.0.0/16"
+
+# Define stacks
+cdk_app = cdk.App()
 
 # recursively apply tags to all stack resources
 if environment_tags:

--- a/app.py
+++ b/app.py
@@ -21,21 +21,21 @@ match environment:
         environment_variables = {
             "VPC_CIDR": "10.254.174.0/24",
             "FQDN": "prod.agora.io",
-            "CERTIFICATE_RESOURCE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
+            "CERTIFICATE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
     case "stage":
         environment_variables = {
             "VPC_CIDR": "10.254.173.0/24",
             "FQDN": "stage.agora.io",
-            "CERTIFICATE_RESOURCE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
+            "CERTIFICATE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
     case "dev":
         environment_variables = {
             "VPC_CIDR": "10.254.172.0/24",
             "FQDN": "dev.agora.io",
-            "CERTIFICATE_RESOURCE_ID": "e8093404-7db1-4042-90d0-01eb5bde1ffc",
+            "CERTIFICATE_ID": "e8093404-7db1-4042-90d0-01eb5bde1ffc",
             "TAGS": {"CostCenter": "Agora / 112300"},
         }
     case _:
@@ -175,7 +175,7 @@ apex_stack = LoadBalancedServiceStack(
     cluster=ecs_stack.cluster,
     props=apex_props,
     load_balancer=load_balancer_stack.alb,
-    certificate_resource_id=environment_variables["CERTIFICATE_RESOURCE_ID"],
+    certificate_id=environment_variables["CERTIFICATE_ID"],
     health_check_path="/health",
 )
 apex_stack.add_dependency(app_stack)

--- a/src/bastion_props.py
+++ b/src/bastion_props.py
@@ -9,7 +9,6 @@ class BastionProps:
     key_name: Name of an existing EC2 KeyPair to enable SSH access to the instance
     instance_type: The EC2 instance type
     ami_id: AMI ID of the base AMI
-    ami_region: Region of the AMI to deploy
     block_devices: Optional block devices to override the base AMI settings
     """
 
@@ -18,13 +17,11 @@ class BastionProps:
         key_name: str,
         instance_type: ec2.InstanceType,
         ami_id: str,
-        ami_region: str,
         block_devices: Optional[Sequence[ec2.BlockDevice]] = None,
     ) -> None:
         self.key_name = key_name
         self.instance_type = instance_type
         self.ami_id = ami_id
-        self.ami_region = ami_region
         if block_devices is None:
             self.block_devices = []
         else:

--- a/src/bastion_stack.py
+++ b/src/bastion_stack.py
@@ -41,13 +41,15 @@ class BastionStack(cdk.Stack):
             self, "BastionKeyPair", props.key_name
         )
 
+        region_json = cdk.CfnJson(self, "AmiRegionJson", value=self.region)
+
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/Instance.html
         self.instance = ec2.Instance(
             self,
             "BastionHost",
             instance_type=props.instance_type,
             machine_image=ec2.MachineImage.generic_linux(
-                {props.ami_region: props.ami_id}
+                {region_json.to_string(): props.ami_id}
             ),
             vpc=vpc,
             key_pair=key_pair,

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -217,7 +217,8 @@ class LoadBalancedServiceStack(ServiceStack):
         cluster: ecs.Cluster,
         props: ServiceProps,
         load_balancer: elbv2.ApplicationLoadBalancer,
-        certificate_arn: str,
+        certificate_account_id: str,
+        certificate_resource_id: str,
         health_check_path: str = "/",
         health_check_interval: int = 1,  # max is 5
         **kwargs,
@@ -227,6 +228,7 @@ class LoadBalancedServiceStack(ServiceStack):
         # -------------------
         # ACM Certificate for HTTPS
         # -------------------
+        certificate_arn = f"arn:aws:acm:${self.region}:${certificate_account_id}:certificate/${certificate_resource_id}"
         self.cert = acm.Certificate.from_certificate_arn(
             self, "Cert", certificate_arn=certificate_arn
         )

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -217,7 +217,7 @@ class LoadBalancedServiceStack(ServiceStack):
         cluster: ecs.Cluster,
         props: ServiceProps,
         load_balancer: elbv2.ApplicationLoadBalancer,
-        certificate_resource_id: str,
+        certificate_id: str,
         health_check_path: str = "/",
         health_check_interval: int = 1,  # max is 5
         **kwargs,
@@ -227,7 +227,9 @@ class LoadBalancedServiceStack(ServiceStack):
         # -------------------
         # ACM Certificate for HTTPS
         # -------------------
-        certificate_arn = f"arn:aws:acm:{self.region}:{self.account}:certificate/{certificate_resource_id}"
+        certificate_arn = (
+            f"arn:aws:acm:{self.region}:{self.account}:certificate/{certificate_id}"
+        )
         self.cert = acm.Certificate.from_certificate_arn(
             self, "Cert", certificate_arn=certificate_arn
         )

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -217,7 +217,6 @@ class LoadBalancedServiceStack(ServiceStack):
         cluster: ecs.Cluster,
         props: ServiceProps,
         load_balancer: elbv2.ApplicationLoadBalancer,
-        certificate_account_id: str,
         certificate_resource_id: str,
         health_check_path: str = "/",
         health_check_interval: int = 1,  # max is 5
@@ -228,7 +227,7 @@ class LoadBalancedServiceStack(ServiceStack):
         # -------------------
         # ACM Certificate for HTTPS
         # -------------------
-        certificate_arn = f"arn:aws:acm:${self.region}:${certificate_account_id}:certificate/${certificate_resource_id}"
+        certificate_arn = f"arn:aws:acm:{self.region}:{self.account}:certificate/{certificate_resource_id}"
         self.cert = acm.Certificate.from_certificate_arn(
             self, "Cert", certificate_arn=certificate_arn
         )

--- a/tests/unit/test_bastion_stack.py
+++ b/tests/unit/test_bastion_stack.py
@@ -15,7 +15,6 @@ def test_bastion_created():
         key_name=key_name,
         instance_type=ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
         ami_id="ami-074a6fac5773fe883",
-        ami_region="us-east-1",
     )
     bastion_stack = BastionStack(
         scope=cdk_app,


### PR DESCRIPTION
## Description

PR #19 included a global var for the AWS region that looked up the value from `aws_cdk.App().region`. However, this returns `None`, so the [workflow job failed](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions/runs/13035826897/job/36365890608). This PR will instead get the region value from the workflow input.  