### PR TITLE
IT-4243: hardcode ami region

### DIFF
--- a/app.py
+++ b/app.py
@@ -182,6 +182,7 @@ bastion_props = BastionProps(
     key_name="agora-ci",
     instance_type=ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
     ami_id="ami-074a6fac5773fe883",
+    ami_region="us-east-1",
 )
 bastion_stack = BastionStack(
     scope=cdk_app,

--- a/src/bastion_props.py
+++ b/src/bastion_props.py
@@ -9,6 +9,7 @@ class BastionProps:
     key_name: Name of an existing EC2 KeyPair to enable SSH access to the instance
     instance_type: The EC2 instance type
     ami_id: AMI ID of the base AMI
+    ami_region: Region of base AMI
     block_devices: Optional block devices to override the base AMI settings
     """
 
@@ -17,11 +18,13 @@ class BastionProps:
         key_name: str,
         instance_type: ec2.InstanceType,
         ami_id: str,
+        ami_region: str,
         block_devices: Optional[Sequence[ec2.BlockDevice]] = None,
     ) -> None:
         self.key_name = key_name
         self.instance_type = instance_type
         self.ami_id = ami_id
+        self.ami_region = ami_region
         if block_devices is None:
             self.block_devices = []
         else:

--- a/src/bastion_stack.py
+++ b/src/bastion_stack.py
@@ -41,15 +41,13 @@ class BastionStack(cdk.Stack):
             self, "BastionKeyPair", props.key_name
         )
 
-        region_json = cdk.CfnJson(self, "AmiRegionJson", value=self.region)
-
         # https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ec2/Instance.html
         self.instance = ec2.Instance(
             self,
             "BastionHost",
             instance_type=props.instance_type,
             machine_image=ec2.MachineImage.generic_linux(
-                {region_json.to_string(): props.ami_id}
+                {props.ami_region: props.ami_id}
             ),
             vpc=vpc,
             key_pair=key_pair,

--- a/tests/unit/test_bastion_stack.py
+++ b/tests/unit/test_bastion_stack.py
@@ -15,6 +15,7 @@ def test_bastion_created():
         key_name=key_name,
         instance_type=ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
         ami_id="ami-074a6fac5773fe883",
+        ami_region="us-east-1",
     )
     bastion_stack = BastionStack(
         scope=cdk_app,


### PR DESCRIPTION
The previous workflow [failed](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions/runs/13058321603/job/36434868749) due to the `CfnJson` lookup not working, so hardcoding the AMI region for now.