### PR TITLE
Fix bastian role

### DIFF
--- a/app.py
+++ b/app.py
@@ -179,7 +179,7 @@ apex_stack.add_dependency(app_stack)
 apex_stack.add_dependency(api_stack)
 
 bastion_props = BastionProps(
-    key_name="agora-ci",
+    key_name="agora-access",
     instance_type=ec2.InstanceType.of(ec2.InstanceClass.T3, ec2.InstanceSize.MICRO),
     ami_id="ami-074a6fac5773fe883",
     ami_region="us-east-1",

--- a/src/bastion_stack.py
+++ b/src/bastion_stack.py
@@ -33,8 +33,8 @@ class BastionStack(cdk.Stack):
                 )
             ],
         )
-        instance_profile = iam.CfnInstanceProfile(
-            self, "BastionInstanceProfile", roles=[role.role_name]
+        instance_profile = iam.InstanceProfile(
+            self, "BastionInstanceProfile", role=role
         )
 
         key_pair = ec2.KeyPair.from_key_pair_name(


### PR DESCRIPTION
* The AmazonSSMManagedInstanceCore was missing from the instance. Change from using CDK level 1 to a level 2 construct seems to fix it.
* Existing agora instances are using `agora-access` keypair.

