### PR TITLE
AG-1680: use image short SHA tag when agora_version is 'edge'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+GITHUB_TOKEN="your-token-here"
+ENV="dev"

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -51,3 +51,4 @@ jobs:
         run: cdk deploy --all --concurrency 5 --require-approval never
         env:
           ENV: ${{ inputs.environment }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+      - name: Install AWS CDK CLI
+        run: npm install -g aws-cdk
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Generate cloudformation

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,11 +24,7 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt -r requirements-dev.txt
       - name: Generate cloudformation
-        uses: youyo/aws-cdk-github-actions@v2
         env:
           ENV: ${{ inputs.environment }}
-        with:
-          cdk_subcommand: 'synth'
-          actions_comment: false
-          debug_log: true
-          cdk_args: '--output ./cdk.out'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: cdk synth --output ./cdk.out

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ Please install pre-commit, once installed the file validations will
 automatically run on every commit.  Alternatively you can manually
 execute the validations by running `pre-commit run --all-files`.
 
+Create a [GitHub classic PAT](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic) with `read:packages` access, then create a .env file using .env.example as a template.
+
 Verify CDK to Cloudformation conversion by running [cdk synth]:
 
 ```console
-ENV=dev cdk synth
+env $(cat .env | xargs) cdk synth
 ```
 
 The Cloudformation output is saved to the `cdk.out` folder
@@ -240,7 +242,7 @@ Deployment requires setting up an [AWS profile](https://docs.aws.amazon.com/cli/
 then executing the following command:
 
 ```console
-AWS_PROFILE=itsandbox-dev AWS_DEFAULT_REGION=us-east-1 ENV=dev cdk deploy --all
+env $(cat .env | xargs) AWS_PROFILE=itsandbox-dev AWS_DEFAULT_REGION=us-east-1 cdk deploy --all
 ```
 
 ## Force new deployment

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
 
 from src.ecs_stack import EcsStack
+from src.helpers.get_package_version import get_alternate_tag_for_edge_package_version
 from src.load_balancer_stack import LoadBalancerStack
 from src.network_stack import NetworkStack
 from src.service_props import ServiceProps, ServiceSecret
@@ -47,10 +48,28 @@ match environment:
 stack_name_prefix = f"agora-{environment}"
 fully_qualified_domain_name = environment_variables["FQDN"]
 environment_tags = environment_variables["TAGS"]
-agora_version = "4.0.0-rc2"
+agora_version = "edge"
 docdb_master_username = "master"
 mongodb_port = 27017
 vpn_cidr = "10.1.0.0/16"
+
+# Get image versions
+if agora_version == "edge":
+    app_version = get_alternate_tag_for_edge_package_version(
+        "Sage-Bionetworks", "agora-app"
+    )
+    api_version = get_alternate_tag_for_edge_package_version(
+        "Sage-Bionetworks", "agora-api"
+    )
+    apex_version = get_alternate_tag_for_edge_package_version(
+        "Sage-Bionetworks", "agora-apex"
+    )
+else:
+    app_version = api_version = apex_version = agora_version
+
+print(
+    f"Using images: agora-app:{app_version}, agora-api:{api_version}, agora-apex:{apex_version}"
+)
 
 # Define stacks
 cdk_app = cdk.App()
@@ -102,7 +121,7 @@ load_balancer_stack = LoadBalancerStack(
 
 api_props = ServiceProps(
     container_name="agora-api",
-    container_location=f"ghcr.io/sage-bionetworks/agora-api:{agora_version}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-api:{api_version}",
     container_port=3333,
     container_memory=1024,
     container_env_vars={
@@ -134,7 +153,7 @@ api_stack.service.connections.allow_to_default_port(
 
 app_props = ServiceProps(
     container_name="agora-app",
-    container_location=f"ghcr.io/sage-bionetworks/agora-app:{agora_version}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-app:{app_version}",
     container_port=4200,
     container_memory=200,
     container_env_vars={
@@ -155,7 +174,7 @@ app_stack.add_dependency(api_stack)
 
 apex_props = ServiceProps(
     container_name="agora-apex",
-    container_location=f"ghcr.io/sage-bionetworks/agora-apex:{agora_version}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-apex:{apex_version}",
     container_port=80,
     container_memory=200,
     container_env_vars={

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aws-cdk-lib~=2.176
 constructs~=10.0
 boto3~=1.34
+requests~=2.32.3

--- a/src/helpers/get_package_version.py
+++ b/src/helpers/get_package_version.py
@@ -1,0 +1,67 @@
+import requests
+import os
+from typing import TypedDict, List, Literal
+
+# https://docs.github.com/en/rest/packages/packages?apiVersion=2022-11-28#list-package-versions-for-a-package-owned-by-an-organization
+
+
+class ContainerMetadata(TypedDict):
+    tags: List[str]
+
+
+class PackageMetadata(TypedDict):
+    package_type: Literal["container"]
+    container: ContainerMetadata
+
+
+class PackageVersion(TypedDict):
+    id: int
+    id: int
+    name: str
+    url: str
+    package_html_url: str
+    created_at: str
+    updated_at: str
+    html_url: str
+    metadata: PackageMetadata
+
+
+class PackageVersionList:
+    List[PackageVersion]
+
+
+def get_package_versions(owner: str, package_name: str) -> PackageVersionList:
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if not github_token:
+        raise SystemExit("Must set environment variable `GITHUB_TOKEN`.")
+
+    url = f"https://api.github.com/orgs/{owner}/packages/container/{package_name}/versions"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {github_token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()  # Raise HTTPError for bad responses (4xx or 5xx)
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        raise SystemExit(f"Error: API request failed: {e}")
+
+
+def get_edge_package_version(versions: PackageVersionList) -> PackageVersion:
+    version: PackageVersion
+    for version in versions:
+        if "edge" in version["metadata"]["container"]["tags"]:
+            return version
+
+
+def get_nonedge_tag(tags: List[str]) -> str:
+    return [tag for tag in tags if tag != "edge"][0]
+
+
+def get_alternate_tag_for_edge_package_version(owner: str, package_name: str):
+    versions = get_package_versions(owner, package_name)
+    edge_version = get_edge_package_version(versions)
+    return get_nonedge_tag(edge_version["metadata"]["container"]["tags"])


### PR DESCRIPTION
## Description

Currently to trigger a new dev deployment, we create a new git tag in sage-monorepo, which triggers a job that pushes new images tagged with the version to GHCR. Then we create and merge a PR to update [`agora_version`](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/blob/dev/app.py#L50) to trigger the deployment. We would like to simplify this process to reduce the effort to update the Agora dev site.

The sage-monorepo already publishes new images tagged with "edge" and the short commit SHA to GHCR whenever we update Agora. For example, see [agora-app](https://github.com/Sage-Bionetworks/sage-monorepo/pkgs/container/agora-app). We would like to re-run the [`deploy-dev` job](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions/workflows/deploy-dev.yaml) to deploy these new containers to our dev site. However, since Cloudformation is idempotent, we can't simply use "edge" in each service's `container_location` because the Cloudformation file would be unchanged between workflow runs, so the stack would not be redeployed. 

This PR uses the GitHub API to look up the image tagged "edge" for each service, then uses the short SHA tag on that image to specify the `container_location`. This will allow us to rerun the `deploy-dev` job, because the Cloudformation file will change to reflect the new image's short commit SHA and a new stack will be deployed.

## Related Issues

- [AG-1680](https://sagebionetworks.jira.com/browse/AG-1680)

[AG-1680]: https://sagebionetworks.jira.com/browse/AG-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ