### PR TITLE
AG-1680: use app_version for APP_VERSION so that SHA is displayed in footer when edge image is used

### DIFF
--- a/app.py
+++ b/app.py
@@ -157,10 +157,10 @@ app_props = ServiceProps(
     container_port=4200,
     container_memory=200,
     container_env_vars={
-        "APP_VERSION": f"{agora_version}",
+        "APP_VERSION": f"{app_version}",
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         "SSR_API_URL": "http://agora-api:3333/api/v1",
-        "TAG_NAME": f"agora/v${agora_version}",
+        "TAG_NAME": f"agora/v${app_version}",
     },
 )
 app_stack = ServiceStack(


### PR DESCRIPTION
## Description

The APP_VERSION is used in the [Agora footer](https://newagora-dev.adknowledgeportal.org/) to help our validator identify when the app has been updated: 

<img width="422" alt="image" src="https://github.com/user-attachments/assets/2ef9eb9e-579e-4887-ad83-0c33474f1705" />


For edge releases, currently the footer will always show "edge", so it will be difficult to tell when the site has been updated. Instead, we should use `app_version`, so that the short commit SHA will be displayed when we're pushing an edge release. For example, our [current edge release](https://github.com/orgs/Sage-Bionetworks/packages/container/agora-app/356179810?tag=sha-1b703e8) should display "sha-1b703e8" instead of  "edge".

For non-edge releases, we will still display the tag (e.g. `agora/v4.0.0-rc3`), since [`app_version` will have the same value as `agora_version`](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/blob/dev/app.py#L67-L68).