### PR TITLE
AG-1741: increase task resourcing to match current agora

### DIFF
--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -84,8 +84,8 @@ class ServiceStack(cdk.Stack):
         self.task_definition = ecs.FargateTaskDefinition(
             self,
             "TaskDef",
-            cpu=1024,
-            memory_limit_mib=4096,
+            cpu=2048,
+            memory_limit_mib=8192,
             task_role=task_role,
             execution_role=execution_role,
         )


### PR DESCRIPTION
We have seen intermittent 502/504 errors on the new Agora dev site. ECS logs show nearly 100% CPU utilization and `JavaScript heap out of memory` errors in the `agora-api` logs at these times. This PR increases task resourcing to match the current Agora sites. See [AG-1741](https://sagebionetworks.jira.com/browse/AG-1741) for more context.

[AG-1741]: https://sagebionetworks.jira.com/browse/AG-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ