### PR TITLE
AG-1741: set soft limit for container memory, so containers can utilize more task memory when needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ from src.service_props import ServiceProps, ServiceSecret
 app_service_props = ServiceProps(
     container_name="app",
     container_port=443,
-    container_memory=1024,
+    container_memory_reservation=1024,
     container_location="ghcr.io/sage-bionetworks/app:v1.0",
     container_secrets=[
         ServiceSecret(

--- a/app.py
+++ b/app.py
@@ -126,7 +126,7 @@ api_props = ServiceProps(
     container_name="agora-api",
     container_location=f"ghcr.io/sage-bionetworks/agora-api:{api_version}",
     container_port=3333,
-    container_memory=1024,
+    container_memory_reservation=2048,
     container_env_vars={
         "NODE_ENV": "development",
         "MONGODB_PORT": f"{mongodb_port}",
@@ -160,7 +160,7 @@ app_props = ServiceProps(
     container_name="agora-app",
     container_location=f"ghcr.io/sage-bionetworks/agora-app:{app_version}",
     container_port=4200,
-    container_memory=200,
+    container_memory_reservation=1024,
     container_env_vars={
         "APP_VERSION": f"{app_version}",
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
@@ -183,7 +183,7 @@ apex_props = ServiceProps(
     container_name="agora-apex",
     container_location=f"ghcr.io/sage-bionetworks/agora-apex:{apex_version}",
     container_port=80,
-    container_memory=200,
+    container_memory_reservation=200,
     container_env_vars={
         "API_HOST": "agora-api",
         "API_PORT": "3333",

--- a/src/service_props.py
+++ b/src/service_props.py
@@ -53,7 +53,7 @@ class ServiceProps:
       supports "path://" for building container from local (i.e. path://docker/MyContainer)
       supports docker registry references (i.e. ghcr.io/sage-bionetworks/app:latest)
     container_port: the container application port
-    container_memory: the container application memory
+    container_memory_reservation: the soft limit of memory to reserve from the task memory for the container application
     container_env_vars: a json dictionary of environment variables to pass into the container
       i.e. {"EnvA": "EnvValueA", "EnvB": "EnvValueB"}
     container_secrets: List of `ServiceSecret` resources to pull from AWS secrets manager
@@ -69,7 +69,7 @@ class ServiceProps:
         container_name: str,
         container_location: str,
         container_port: int,
-        container_memory: int = 512,
+        container_memory_reservation: int = 512,
         container_env_vars: dict = None,
         container_secrets: List[ServiceSecret] = None,
         container_volumes: List[ContainerVolume] = None,
@@ -80,7 +80,7 @@ class ServiceProps:
     ) -> None:
         self.container_name = container_name
         self.container_port = container_port
-        self.container_memory = container_memory
+        self.container_memory_reservation = container_memory_reservation
         if CONTAINER_LOCATION_PATH_ID in container_location:
             container_location = container_location.removeprefix(
                 CONTAINER_LOCATION_PATH_ID

--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -109,7 +109,7 @@ class ServiceStack(cdk.Stack):
         self.container = self.task_definition.add_container(
             props.container_name,
             image=image,
-            memory_limit_mib=props.container_memory,
+            memory_reservation_mib=props.container_memory_reservation,
             environment=props.container_env_vars,
             secrets=secrets,
             port_mappings=[

--- a/tests/unit/test_service_stack.py
+++ b/tests/unit/test_service_stack.py
@@ -19,7 +19,7 @@ def test_service_stack_created():
         container_name="app",
         container_location="ghcr.io/sage-bionetworks/app:1.0",
         container_port=8010,
-        container_memory=200,
+        container_memory_reservation=200,
         container_secrets=[
             ServiceSecret(
                 secret_name="/app/secret",
@@ -45,7 +45,7 @@ def test_service_stack_created():
             "ContainerDefinitions": [
                 {
                     "Image": "ghcr.io/sage-bionetworks/app:1.0",
-                    "Memory": 200,
+                    "MemoryReservation": 200,
                     "MountPoints": [{"ContainerPath": "/work"}],
                     "Secrets": [{"Name": "APP_SECRET"}],
                     "Command": ["test"],


### PR DESCRIPTION
## Description

We have seen intermittent 502/504 errors on the new Agora dev site. The previous PR increased task resourcing to match the current Agora sites (#36), but I was still able to reproduce the `JavaScript heap out of memory` error in `agora-api` by switching between categories and models on the GCT. The task CPU utilization spiked to 80%, but task memory utilization maxed out at ~12%.

<img width="1150" alt="image" src="https://github.com/user-attachments/assets/89318dd7-9bf3-4f3c-b065-5367d19c8e48" />   
<br><br/>

I found that the agora-api container was configured to have a hard limit of 1GB for memory (which is ~12% of the task's 8GB memory). So although the _task_ memory limit was increased, the _container_ memory limit remained the same. 

This PR sets a soft limit rather than a hard limit on memory for the container, so the container can access more memory from the task when needed. See AWS docs [here](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#container_definition_memory). 

## Related Issues

- [AG-1741](https://sagebionetworks.jira.com/browse/AG-1741)

## Changelog

- Use `memory_reservation` to set soft limit on memory to reserve for the container, rather than a hard limit with `memory`
- Increase amount of memory reserved for the agora-api and agora-app containers

[AG-1741]: https://sagebionetworks.jira.com/browse/AG-1741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ