### PR TITLE
AG-1741: decrease task memory

### DIFF
--- a/src/service_stack.py
+++ b/src/service_stack.py
@@ -85,7 +85,7 @@ class ServiceStack(cdk.Stack):
             self,
             "TaskDef",
             cpu=2048,
-            memory_limit_mib=8192,
+            memory_limit_mib=4096,
             task_role=task_role,
             execution_role=execution_role,
         )


### PR DESCRIPTION
The last PR (#37) seems to have resolved the intermittent 502/504 errors during my testing of the GCT. The `agora-api` service appears to utilize the extra CPU added in #36, but the task may have more memory than is needed. Reduce to the smallest memory where 2 vCPU is a valid value per the [AWS docs](https://docs.aws.amazon.com/cdk/api/v2/python/aws_cdk.aws_ecs/FargateTaskDefinitionProps.html). Health metrics for the `agora-api` service over the last day: 

<img width="1871" alt="image" src="https://github.com/user-attachments/assets/2bd28d7d-7186-41b2-9462-48f55f42e1f8" />
