### PR TITLE
AG-1754 adding url length rule to handle long urls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aws-cdk-lib~=2.176
+aws-cdk-lib==2.189.1
 constructs~=10.0
 boto3~=1.34
 requests~=2.32.3

--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -48,7 +48,7 @@ class LoadBalancerStack(cdk.Stack):
                                 wafv2.CfnWebACL.RuleActionOverrideProperty(
                                     name="SizeRestrictions_QUERYSTRING",
                                     action_to_use=wafv2.CfnWebACL.RuleActionProperty(
-                                        block={}  # This effectively disables the rule
+                                        allow={}
                                     ),
                                 )
                             ],

--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -79,31 +79,6 @@ class LoadBalancerStack(cdk.Stack):
                         metric_name="AWSManagedRulesKnownBadInputsRuleSet",
                     ),
                 ),
-                # Custom rule to limit URL length to 4000 characters
-                wafv2.CfnWebACL.RuleProperty(
-                    name="LimitURLLength",
-                    priority=2,
-                    statement=wafv2.CfnWebACL.StatementProperty(
-                        size_constraint_statement=wafv2.CfnWebACL.SizeConstraintStatementProperty(
-                            comparison_operator="GT",
-                            size=4000,
-                            field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(
-                                uri_path={}
-                            ),
-                            text_transformations=[
-                                wafv2.CfnWebACL.TextTransformationProperty(
-                                    priority=1, type="NONE"
-                                )
-                            ],
-                        )
-                    ),
-                    action=wafv2.CfnWebACL.RuleActionProperty(block={}),
-                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
-                        cloud_watch_metrics_enabled=True,
-                        metric_name="LimitURLLength",
-                        sampled_requests_enabled=True,
-                    ),
-                ),
             ],
         )
 

--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -82,7 +82,7 @@ class LoadBalancerStack(cdk.Stack):
                             field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(
                                 uri_path={}
                             ),
-                            text_transformation=[
+                            text_transformations=[
                                 wafv2.CfnWebACL.TextTransformationProperty(
                                     priority=1, type="NONE"
                                 )

--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -44,6 +44,14 @@ class LoadBalancerStack(cdk.Stack):
                         managed_rule_group_statement=wafv2.CfnWebACL.ManagedRuleGroupStatementProperty(
                             name="AWSManagedRulesCommonRuleSet",
                             vendor_name="AWS",
+                            rule_action_overrides=[
+                                wafv2.CfnWebACL.RuleActionOverrideProperty(
+                                    name="SizeRestrictions_QUERYSTRING",
+                                    action_to_use=wafv2.CfnWebACL.RuleActionProperty(
+                                        block={}  # This effectively disables the rule
+                                    ),
+                                )
+                            ],
                         )
                     ),
                     override_action=wafv2.CfnWebACL.OverrideActionProperty(none={}),

--- a/src/load_balancer_stack.py
+++ b/src/load_balancer_stack.py
@@ -71,6 +71,31 @@ class LoadBalancerStack(cdk.Stack):
                         metric_name="AWSManagedRulesKnownBadInputsRuleSet",
                     ),
                 ),
+                # Custom rule to limit URL length to 4000 characters
+                wafv2.CfnWebACL.RuleProperty(
+                    name="LimitURLLength",
+                    priority=2,
+                    statement=wafv2.CfnWebACL.StatementProperty(
+                        size_constraint_statement=wafv2.CfnWebACL.SizeConstraintStatementProperty(
+                            comparison_operator="GT",
+                            size=4000,
+                            field_to_match=wafv2.CfnWebACL.FieldToMatchProperty(
+                                uri_path={}
+                            ),
+                            text_transformation=[
+                                wafv2.CfnWebACL.TextTransformationProperty(
+                                    priority=1, type="NONE"
+                                )
+                            ],
+                        )
+                    ),
+                    action=wafv2.CfnWebACL.RuleActionProperty(block={}),
+                    visibility_config=wafv2.CfnWebACL.VisibilityConfigProperty(
+                        cloud_watch_metrics_enabled=True,
+                        metric_name="LimitURLLength",
+                        sampled_requests_enabled=True,
+                    ),
+                ),
             ],
         )
 

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -4,7 +4,7 @@
 set -euxo pipefail
 
 # Install Node.js dependencies
-npm install -g aws-cdk@2.176.0
+npm install -g aws-cdk@2.1007.0
 
 # Install Python dependencies
 python -m venv .venv


### PR DESCRIPTION
### Description
Agora's GCT page allows users to share urls with genes and specify filter preferences in the URL requiring more characters to be allowed in the URL.
Agora's Similar Genes page also requires the ability for the URL to handle 220+ genes.

### Changelog
This PR increases the allowable characters in the URL to 4000 to enable existing functionality to function.

Updated aws-cdk to the latest as I could not run with the existing version.

Jira [link](https://sagebionetworks.jira.com/jira/software/c/projects/AG/boards/240?selectedIssue=AG-1754)
