### PR TITLE
AG-1648: set Google Tag Manager ID

### DIFF
--- a/app.py
+++ b/app.py
@@ -166,6 +166,7 @@ app_props = ServiceProps(
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         "SSR_API_URL": "http://agora-api:3333/api/v1",
         "TAG_NAME": f"agora/v${app_version}",
+        "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
     auto_scale_max_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["max"],


### PR DESCRIPTION
## Description

We are configuring Agora to use Google Tag Manager and need to set the Google Tag Manager ID in the deployed app container.

Depends on https://github.com/Sage-Bionetworks/sage-monorepo/pull/3089

## Related Issue

- [AG-1648](https://sagebionetworks.jira.com/browse/AG-1648)

[AG-1648]: https://sagebionetworks.jira.com/browse/AG-1648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ