### PR TITLE
AG-1775: fix TAG_NAME formatting and handle case where edge image does not have SHA tag

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ app_props = ServiceProps(
         "APP_VERSION": f"{app_version}",
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         "SSR_API_URL": "http://agora-api:3333/api/v1",
-        "TAG_NAME": f"agora/v${app_version}",
+        "TAG_NAME": f"agora/v{app_version}",
         "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],

--- a/src/helpers/get_package_version.py
+++ b/src/helpers/get_package_version.py
@@ -58,6 +58,8 @@ def get_edge_package_version(versions: PackageVersionList) -> PackageVersion:
 
 
 def get_nonedge_tag(tags: List[str]) -> str:
+    if len(tags) == 1:
+        return tags[0]
     return [tag for tag in tags if tag != "edge"][0]
 
 


### PR DESCRIPTION
[AG-1775](https://sagebionetworks.jira.com/browse/AG-1775): The app footer should use the `TAG_NAME` to find and display the SHA associated with the git tag. While the SHA is displayed as expected while running the app locally, the SHA is not displayed in the footer on `stage` or `prod`. This PR removes a stray `$` so the `TAG_NAME` is correctly formatted like `agora/v4.0.0-rc4` instead of `agora/v$4.0.0-rc4`, which matches the expected [tag format](https://github.com/Sage-Bionetworks/sage-monorepo/tags) and should allow the SHA to be looked up in `stage` and `prod.

Separately, we expected that the image tagged `edge` would always have a SHA tag as well. However, when a release is created for the same commit, the SHA tag is moved to the image tagged with the release version. See example in [agora-app](https://github.com/sage-bionetworks/sage-monorepo/pkgs/container/agora-app) package below. To handle this case, this PR updates the code to use "edge" for the package version when edge is the only tag on the image.

<img width="786" alt="image" src="https://github.com/user-attachments/assets/0710292a-91e1-4e62-a459-aaebc67d191f" />



[AG-1775]: https://sagebionetworks.jira.com/browse/AG-1775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ