### PR TITLE
AG-1775: fix TAG_NAME formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -165,7 +165,7 @@ app_props = ServiceProps(
         "APP_VERSION": f"{app_version}",
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         "SSR_API_URL": "http://agora-api:3333/api/v1",
-        "TAG_NAME": f"agora/v${app_version}",
+        "TAG_NAME": f"agora/v{app_version}",
         "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],

--- a/src/helpers/get_package_version.py
+++ b/src/helpers/get_package_version.py
@@ -58,6 +58,8 @@ def get_edge_package_version(versions: PackageVersionList) -> PackageVersion:
 
 
 def get_nonedge_tag(tags: List[str]) -> str:
+    if len(tags) == 1:
+        return tags[0]
     return [tag for tag in tags if tag != "edge"][0]
 
 


### PR DESCRIPTION
Fixes `TAG_NAME` in `stage` to confirm that footer now displays SHA.