### PR TITLE
enable deploy-dev workflow to be triggered manually

### DIFF
--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -3,6 +3,7 @@ name: deploy-dev
 on:
   push:
     branches: ['dev']
+  workflow_dispatch:
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tools can be installed by running:
 
 Development requires the activation of the Python virtual environment:
 
-```
+```console
 $ source .venv/bin/activate
 ```
 


### PR DESCRIPTION
## Description

We would like to push the latest code to dev. Generally, we can simply re-run the latest `deploy-dev` job. However, GitHub only allows a job to be [re-run until 30 days after its initial run](https://docs.github.com/en/actions/how-tos/managing-workflow-runs-and-deployments/managing-workflow-runs/re-running-workflows-and-jobs). Since the `deploy-dev` job was initially run more than 30 days ago, we will need to make a code change to trigger `deploy-dev` job or enable the workflow to be run manually.

Here, we add the `workflow_dispatch` trigger, so that we can [manually trigger `deploy-dev` whenever desired](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#workflow_dispatch).