### PR TITLE
AG-1952: add agora-api-next to stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ Stage and prod environments point at a specific git tag that is manually added. 
 4. Create a new branch in your IDE.  Update the new version number in app.py and create a PR in this repo **to the dev branch** that sets `GHCR_PACKAGE_VERSION` for stage and prod environments to the new version number you created previously, since the images are only tagged with the version number (e.g. `4.0.0-rc3`) rather than the full tag name (e.g. `agora/v4.0.0-rc3` ).
 5. Merge PR. Wait for [deploy-dev job](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions/workflows/deploy-dev.yaml) to successfully update dev deployment. Deployment can be monitored in AWS console in AWS ECS.
 6. Create PR in this repo **to merge dev into the stage branch**.  You can use this [url](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/compare/stage...dev)
-7. Merge PR. Wait for [deploy-stage GHA job](https://github.com/Sage-Bionetworks-IT/modeladexplorer-v3/actions/workflows/deploy-stage.yaml) to successfully update staging deployment. Deployment can be monitored in AWS console in AWS ECS.
+7. Merge PR. Wait for [deploy-stage GHA job](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions/workflows/deploy-stage.yaml) to successfully update staging deployment. Deployment can be monitored in AWS console in AWS ECS.
 8. Confirm that [staging site](https://agora-stage.adknowledgeportal.org/) shows new version’s tag in the app footer.
 
 ## Production Deployment
@@ -409,5 +409,5 @@ Stage and prod environments point at a specific git tag that is manually added. 
    - Confirm that the new tag is on the same commit as the previous tag by reviewing the git log: `git log --oneline`
    - Push the tag: `git push upstream tag agora/release/v4.0.0`
 3. Create a PR in this repo **to merge the stage branch into the prod branch**. You can use this [url](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/compare/prod...stage).
-4. Merge PR. Wait for the [deploy-prod GHA job](https://github.com/Sage-Bionetworks-IT/modeladexplorer-v3/actions/workflows/deploy-prod.yaml) to successfully update prod deployment. Deployment can be monitored in AWS console in AWS ECS.
+4. Merge PR. Wait for the [deploy-prod GHA job](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions/workflows/deploy-prod.yaml) to successfully update prod deployment. Deployment can be monitored in AWS console in AWS ECS.
 5. Confirm that [production site](https://agora.adknowledgeportal.org/) shows the same tag in the app footer as the staging site.

--- a/app.py
+++ b/app.py
@@ -67,14 +67,18 @@ if ghcr_package_version == "edge":
     api_version = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "agora-api"
     )
+    api_next_version = get_alternate_tag_for_edge_package_version(
+        "Sage-Bionetworks", "agora-api-next"
+    )
     apex_version = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "agora-apex"
     )
 else:
-    app_version = api_version = apex_version = ghcr_package_version
+    app_version = api_version = api_next_version = apex_version = ghcr_package_version
 
 print(
-    f"Using images: agora-app:{app_version}, agora-api:{api_version}, agora-apex:{apex_version}"
+    f"Using images: agora-app:{app_version}, agora-api:{api_version}, "
+    f"agora-api-next:{api_next_version}, agora-apex:{apex_version}"
 )
 
 # Define stacks
@@ -159,6 +163,42 @@ api_stack.service.connections.allow_to_default_port(
     "Allow API container to connect to DocumentDB cluster",
 )
 
+api_next_props = ServiceProps(
+    container_name="agora-api-next",
+    container_location=f"ghcr.io/sage-bionetworks/agora-api-next:{api_next_version}",
+    container_port=3334,
+    container_memory_reservation=2048,
+    container_env_vars={
+        "SERVER_PORT": "3334",
+        "SPRING_DATA_MONGODB_HOST": docdb_stack.cluster.cluster_endpoint.hostname,
+        "SPRING_DATA_MONGODB_PORT": f"{mongodb_port}",
+        "SPRING_DATA_MONGODB_DATABASE": "agora",
+        "SPRING_DATA_MONGODB_USERNAME": docdb_master_username,
+        "SPRING_DATA_MONGODB_AUTHENTICATION_DATABASE": "admin",
+        "SPRING_PROFILES_ACTIVE": f"{environment}",
+    },
+    container_secrets=[
+        ServiceSecret(
+            secret_name=docdb_stack.master_password_secret.secret_name,
+            environment_key="SPRING_DATA_MONGODB_PASSWORD",
+        )
+    ],
+    auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
+    auto_scale_max_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["max"],
+)
+api_next_stack = ServiceStack(
+    scope=cdk_app,
+    construct_id=f"{stack_name_prefix}-api-next",
+    vpc=network_stack.vpc,
+    cluster=ecs_stack.cluster,
+    props=api_next_props,
+)
+api_next_stack.add_dependency(docdb_stack)
+api_next_stack.service.connections.allow_to_default_port(
+    docdb_stack.cluster,
+    "Allow API Next container to connect to DocumentDB cluster",
+)
+
 app_props = ServiceProps(
     container_name="agora-app",
     container_location=f"ghcr.io/sage-bionetworks/agora-app:{app_version}",
@@ -167,6 +207,7 @@ app_props = ServiceProps(
     container_env_vars={
         "APP_VERSION": f"{app_version}",
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
+        # TODO: update this port when agora-api is removed from this stack
         "SSR_API_URL": "http://agora-api:3333/v1",
         "TAG_NAME": f"agora/v{app_version}",
         "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
@@ -182,6 +223,7 @@ app_stack = ServiceStack(
     props=app_props,
 )
 app_stack.add_dependency(api_stack)
+app_stack.add_dependency(api_next_stack)
 
 apex_props = ServiceProps(
     container_name="agora-apex",
@@ -193,6 +235,8 @@ apex_props = ServiceProps(
         "API_PORT": "3333",
         "APP_HOST": "agora-app",
         "APP_PORT": "4200",
+        "API_NEXT_HOST": "agora-api-next",
+        "API_NEXT_PORT": "3334",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
     auto_scale_max_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["max"],
@@ -209,6 +253,7 @@ apex_stack = LoadBalancedServiceStack(
 )
 apex_stack.add_dependency(app_stack)
 apex_stack.add_dependency(api_stack)
+apex_stack.add_dependency(api_next_stack)
 
 bastion_props = BastionProps(
     key_name="agora-access",


### PR DESCRIPTION
[AG-1952](https://sagebionetworks.jira.com/browse/AG-1952): We are migrating from a Node.js Express server to a Java Spring Boot server. We are moving routes to the new server gradually. However, we would like the deployed app to continue functioning while the routes are migrated. This PR adds the new server (`agora-api-next`) to the stack. We plan to remove the old server (`agora-api`) in the future when all routes have been migrated. 

> [!IMPORTANT] 
> These changes depend on https://github.com/Sage-Bionetworks/sage-monorepo/pull/3835.


[AG-1952]: https://sagebionetworks.jira.com/browse/AG-1952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ