### PR TITLE
feat(agora): update code to use commit_sha (AG-2015)

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,10 +4,7 @@ import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
 
 from src.ecs_stack import EcsStack
-from src.helpers.github_helpers import (
-    get_alternate_tag_for_edge_package_version,
-    get_commit_sha_for_tag,
-)
+from src.helpers.github_helpers import get_image_version, get_short_commit_sha
 from src.load_balancer_stack import LoadBalancerStack
 from src.network_stack import NetworkStack
 from src.service_props import ServiceProps, ServiceSecret
@@ -62,37 +59,19 @@ docdb_master_username = "master"
 mongodb_port = 27017
 vpn_cidr = "10.1.0.0/16"
 
-# Get image tags
-if ghcr_package_version == "edge":
-    app_tag = get_alternate_tag_for_edge_package_version(
-        "Sage-Bionetworks", "agora-app"
-    )
-    api_tag = get_alternate_tag_for_edge_package_version(
-        "Sage-Bionetworks", "agora-api"
-    )
-    api_next_tag = get_alternate_tag_for_edge_package_version(
-        "Sage-Bionetworks", "agora-api-next"
-    )
-    apex_tag = get_alternate_tag_for_edge_package_version(
-        "Sage-Bionetworks", "agora-apex"
-    )
-else:
-    app_tag = api_tag = api_next_tag = apex_tag = ghcr_package_version
+# Resolve image tags for each service
+app_version = get_image_version("agora-app", ghcr_package_version)
+api_version = get_image_version("agora-api", ghcr_package_version)
+api_next_version = get_image_version("agora-api-next", ghcr_package_version)
+apex_version = get_image_version("agora-apex", ghcr_package_version)
 
-# Get commit SHA for the version
-if ghcr_package_version == "edge":
-    # For edge, the app_tag is already the full commit SHA
-    short_commit_sha = app_tag[:7]
-else:
-    # For non-edge versions, fetch the commit SHA from the git tag
-    commit_sha = get_commit_sha_for_tag(
-        "Sage-Bionetworks", "sage-monorepo", f"agora/v{app_tag}"
-    )
-    short_commit_sha = commit_sha[:7]
+short_commit_sha = get_short_commit_sha(
+    "sage-monorepo", app_version, ghcr_package_version
+)
 
 print(
-    f"Using images: agora-app:{app_tag}, agora-api:{api_tag}, "
-    f"agora-api-next:{api_next_tag}, agora-apex:{apex_tag}"
+    f"Using images: agora-app:{app_version}, agora-api:{api_version}, "
+    f"agora-api-next:{api_next_version}, agora-apex:{apex_version}"
 )
 
 # Define stacks
@@ -145,7 +124,7 @@ load_balancer_stack = LoadBalancerStack(
 
 api_props = ServiceProps(
     container_name="agora-api",
-    container_location=f"ghcr.io/sage-bionetworks/agora-api:{api_tag}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-api:{api_version}",
     container_port=3333,
     container_memory_reservation=2048,
     container_env_vars={
@@ -179,7 +158,7 @@ api_stack.service.connections.allow_to_default_port(
 
 api_next_props = ServiceProps(
     container_name="agora-api-next",
-    container_location=f"ghcr.io/sage-bionetworks/agora-api-next:{api_next_tag}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-api-next:{api_next_version}",
     container_port=3334,
     container_memory_reservation=2048,
     container_env_vars={
@@ -215,16 +194,16 @@ api_next_stack.service.connections.allow_to_default_port(
 
 app_props = ServiceProps(
     container_name="agora-app",
-    container_location=f"ghcr.io/sage-bionetworks/agora-app:{app_tag}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-app:{app_version}",
     container_port=4200,
     container_memory_reservation=1024,
     container_env_vars={
-        "APP_VERSION": ghcr_package_version,
+        "APP_VERSION": app_version,
         "COMMIT_SHA": short_commit_sha,
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         # TODO: update this port when agora-api is removed from this stack
         "SSR_API_URL": "http://agora-api:3333/v1",
-        "TAG_NAME": f"agora/v{app_tag}",
+        "TAG_NAME": f"agora/v{app_version}",
         "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
@@ -242,7 +221,7 @@ app_stack.add_dependency(api_next_stack)
 
 apex_props = ServiceProps(
     container_name="agora-apex",
-    container_location=f"ghcr.io/sage-bionetworks/agora-apex:{apex_tag}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-apex:{apex_version}",
     container_port=80,
     container_memory_reservation=200,
     container_env_vars={

--- a/app.py
+++ b/app.py
@@ -51,6 +51,7 @@ match environment:
             f"Must set environment variable `ENV` to one of {valid_envs_str}. Currently set to {environment}."
         )
 
+TAG_PREFIX = "agora/v"
 stack_name_prefix = f"agora-{environment}"
 fully_qualified_domain_name = environment_variables["FQDN"]
 environment_tags = environment_variables["TAGS"]
@@ -66,7 +67,7 @@ api_next_version = get_image_version("agora-api-next", ghcr_package_version)
 apex_version = get_image_version("agora-apex", ghcr_package_version)
 
 short_commit_sha = get_short_commit_sha(
-    "sage-monorepo", app_version, ghcr_package_version
+    "sage-monorepo", app_version, ghcr_package_version, tag_prefix=TAG_PREFIX
 )
 
 print(
@@ -203,7 +204,7 @@ app_props = ServiceProps(
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         # TODO: update this port when agora-api is removed from this stack
         "SSR_API_URL": "http://agora-api:3333/v1",
-        "TAG_NAME": f"agora/v{app_version}",
+        "TAG_NAME": f"{TAG_PREFIX}{app_version}",
         "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],

--- a/app.py
+++ b/app.py
@@ -4,7 +4,10 @@ import aws_cdk as cdk
 from aws_cdk import aws_ec2 as ec2
 
 from src.ecs_stack import EcsStack
-from src.helpers.get_package_version import get_alternate_tag_for_edge_package_version
+from src.helpers.github_helpers import (
+    get_alternate_tag_for_edge_package_version,
+    get_commit_sha_for_tag,
+)
 from src.load_balancer_stack import LoadBalancerStack
 from src.network_stack import NetworkStack
 from src.service_props import ServiceProps, ServiceSecret
@@ -59,26 +62,37 @@ docdb_master_username = "master"
 mongodb_port = 27017
 vpn_cidr = "10.1.0.0/16"
 
-# Get image versions
+# Get image tags
 if ghcr_package_version == "edge":
-    app_version = get_alternate_tag_for_edge_package_version(
+    app_tag = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "agora-app"
     )
-    api_version = get_alternate_tag_for_edge_package_version(
+    api_tag = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "agora-api"
     )
-    api_next_version = get_alternate_tag_for_edge_package_version(
+    api_next_tag = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "agora-api-next"
     )
-    apex_version = get_alternate_tag_for_edge_package_version(
+    apex_tag = get_alternate_tag_for_edge_package_version(
         "Sage-Bionetworks", "agora-apex"
     )
 else:
-    app_version = api_version = api_next_version = apex_version = ghcr_package_version
+    app_tag = api_tag = api_next_tag = apex_tag = ghcr_package_version
+
+# Get commit SHA for the version
+if ghcr_package_version == "edge":
+    # For edge, the app_tag is already the full commit SHA
+    short_commit_sha = app_tag[:7]
+else:
+    # For non-edge versions, fetch the commit SHA from the git tag
+    commit_sha = get_commit_sha_for_tag(
+        "Sage-Bionetworks", "sage-monorepo", f"agora/v{app_tag}"
+    )
+    short_commit_sha = commit_sha[:7]
 
 print(
-    f"Using images: agora-app:{app_version}, agora-api:{api_version}, "
-    f"agora-api-next:{api_next_version}, agora-apex:{apex_version}"
+    f"Using images: agora-app:{app_tag}, agora-api:{api_tag}, "
+    f"agora-api-next:{api_next_tag}, agora-apex:{apex_tag}"
 )
 
 # Define stacks
@@ -131,7 +145,7 @@ load_balancer_stack = LoadBalancerStack(
 
 api_props = ServiceProps(
     container_name="agora-api",
-    container_location=f"ghcr.io/sage-bionetworks/agora-api:{api_version}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-api:{api_tag}",
     container_port=3333,
     container_memory_reservation=2048,
     container_env_vars={
@@ -165,7 +179,7 @@ api_stack.service.connections.allow_to_default_port(
 
 api_next_props = ServiceProps(
     container_name="agora-api-next",
-    container_location=f"ghcr.io/sage-bionetworks/agora-api-next:{api_next_version}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-api-next:{api_next_tag}",
     container_port=3334,
     container_memory_reservation=2048,
     container_env_vars={
@@ -201,15 +215,16 @@ api_next_stack.service.connections.allow_to_default_port(
 
 app_props = ServiceProps(
     container_name="agora-app",
-    container_location=f"ghcr.io/sage-bionetworks/agora-app:{app_version}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-app:{app_tag}",
     container_port=4200,
     container_memory_reservation=1024,
     container_env_vars={
-        "APP_VERSION": f"{app_version}",
+        "APP_VERSION": ghcr_package_version,
+        "COMMIT_SHA": short_commit_sha,
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         # TODO: update this port when agora-api is removed from this stack
         "SSR_API_URL": "http://agora-api:3333/v1",
-        "TAG_NAME": f"agora/v{app_version}",
+        "TAG_NAME": f"agora/v{app_tag}",
         "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
     },
     auto_scale_min_capacity=environment_variables["AUTO_SCALE_CAPACITY"]["min"],
@@ -227,7 +242,7 @@ app_stack.add_dependency(api_next_stack)
 
 apex_props = ServiceProps(
     container_name="agora-apex",
-    container_location=f"ghcr.io/sage-bionetworks/agora-apex:{apex_version}",
+    container_location=f"ghcr.io/sage-bionetworks/agora-apex:{apex_tag}",
     container_port=80,
     container_memory_reservation=200,
     container_env_vars={

--- a/src/helpers/github_helpers.py
+++ b/src/helpers/github_helpers.py
@@ -30,6 +30,20 @@ class PackageVersionList:
     List[PackageVersion]
 
 
+# https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#get-a-reference
+class GitObject(TypedDict):
+    type: str
+    sha: str
+    url: str
+
+
+class GitRef(TypedDict):
+    ref: str
+    node_id: str
+    url: str
+    object: GitObject
+
+
 def get_package_versions(owner: str, package_name: str) -> PackageVersionList:
     github_token = os.environ.get("GITHUB_TOKEN")
     if not github_token:
@@ -82,7 +96,11 @@ def get_image_version(
 
 
 def get_short_commit_sha(
-    repo: str, image_tag: str, configured_version: str, owner: str = "Sage-Bionetworks"
+    repo: str,
+    image_tag: str,
+    configured_version: str,
+    owner: str = "Sage-Bionetworks",
+    tag_prefix: str = "",
 ) -> str:
     # Return a short (7 char) commit SHA for the given version.
 
@@ -93,11 +111,11 @@ def get_short_commit_sha(
 
     if configured_version == "edge":
         return image_tag[:7]
-    commit_sha = get_commit_sha_for_tag(owner, repo, f"agora/v{image_tag}")
+    commit_sha = get_commit_sha_for_tag(owner, repo, f"{tag_prefix}{image_tag}")
     return commit_sha[:7]
 
 
-def get_commit_sha_for_tag(owner: str, repo: str, tag: str) -> str:
+def get_git_ref(owner: str, repo: str, tag: str) -> GitRef:
     github_token = os.environ.get("GITHUB_TOKEN")
     if not github_token:
         raise SystemExit("Must set environment variable `GITHUB_TOKEN`.")
@@ -112,18 +130,22 @@ def get_commit_sha_for_tag(owner: str, repo: str, tag: str) -> str:
     try:
         response = requests.get(url, headers=headers)
         response.raise_for_status()
-        ref_data = response.json()
-
-        # The ref points to either a commit or a tag object
-        object_type = ref_data["object"]["type"]
-        object_sha = ref_data["object"]["sha"]
-
-        if object_type == "commit":
-            return object_sha
-        else:
-            raise SystemExit(
-                f"Error: Tag '{tag}' is not a lightweight tag (type: {object_type}). "
-                "Only lightweight tags are supported."
-            )
+        return response.json()
     except requests.exceptions.RequestException as e:
         raise SystemExit(f"Error: GitHub Tag API request failed: {e}")
+
+
+def get_commit_sha_for_tag(owner: str, repo: str, tag: str) -> str:
+    ref_data = get_git_ref(owner, repo, tag)
+
+    # The ref points to either a commit or a tag object
+    object_type = ref_data["object"]["type"]
+    object_sha = ref_data["object"]["sha"]
+
+    if object_type == "commit":
+        return object_sha
+    else:
+        raise SystemExit(
+            f"Error: Tag '{tag}' is not a lightweight tag (type: {object_type}). "
+            "Only lightweight tags are supported."
+        )

--- a/src/helpers/github_helpers.py
+++ b/src/helpers/github_helpers.py
@@ -63,10 +63,38 @@ def get_nonedge_tag(tags: List[str]) -> str:
     return [tag for tag in tags if tag != "edge"][0]
 
 
-def get_alternate_tag_for_edge_package_version(owner: str, package_name: str):
+def get_alternate_tag_for_edge_package_version(
+    package_name: str, owner: str = "Sage-Bionetworks"
+):
     versions = get_package_versions(owner, package_name)
     edge_version = get_edge_package_version(versions)
     return get_nonedge_tag(edge_version["metadata"]["container"]["tags"])
+
+
+def get_image_version(
+    package_name: str, configured_version: str, owner: str = "Sage-Bionetworks"
+) -> str:
+    # For 'edge', returns the alternate tag (typically commit SHA) from the edge image.
+    # For other versions, returns the configured version as-is.
+    if configured_version == "edge":
+        return get_alternate_tag_for_edge_package_version(package_name, owner)
+    return configured_version
+
+
+def get_short_commit_sha(
+    repo: str, image_tag: str, configured_version: str, owner: str = "Sage-Bionetworks"
+) -> str:
+    # Return a short (7 char) commit SHA for the given version.
+
+    # For 'edge', image_tag is typically the commit SHA. However, if a release
+    # is created for the same commit, the SHA tag moves to the release image,
+    # resulting in image_tag being 'edge'.
+    # For other versions, fetches the commit SHA from the git tag.
+
+    if configured_version == "edge":
+        return image_tag[:7]
+    commit_sha = get_commit_sha_for_tag(owner, repo, f"agora/v{image_tag}")
+    return commit_sha[:7]
 
 
 def get_commit_sha_for_tag(owner: str, repo: str, tag: str) -> str:

--- a/src/helpers/github_helpers.py
+++ b/src/helpers/github_helpers.py
@@ -67,3 +67,35 @@ def get_alternate_tag_for_edge_package_version(owner: str, package_name: str):
     versions = get_package_versions(owner, package_name)
     edge_version = get_edge_package_version(versions)
     return get_nonedge_tag(edge_version["metadata"]["container"]["tags"])
+
+
+def get_commit_sha_for_tag(owner: str, repo: str, tag: str) -> str:
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if not github_token:
+        raise SystemExit("Must set environment variable `GITHUB_TOKEN`.")
+
+    url = f"https://api.github.com/repos/{owner}/{repo}/git/ref/tags/{tag}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "Authorization": f"Bearer {github_token}",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        ref_data = response.json()
+
+        # The ref points to either a commit or a tag object
+        object_type = ref_data["object"]["type"]
+        object_sha = ref_data["object"]["sha"]
+
+        if object_type == "commit":
+            return object_sha
+        else:
+            raise SystemExit(
+                f"Error: Tag '{tag}' is not a lightweight tag (type: {object_type}). "
+                "Only lightweight tags are supported."
+            )
+    except requests.exceptions.RequestException as e:
+        raise SystemExit(f"Error: GitHub Tag API request failed: {e}")


### PR DESCRIPTION
## Description
Add commit SHA and refactor image tag handling for container deployments.

## Related Issues
[AG-2015](https://sagebionetworks.jira.com/browse/AG-2015)
[AG-1882](https://sagebionetworks.jira.com/browse/AG-1882)

## Changelog
- Renamed get_package_version.py to github_helpers.py
- Updates the main deployment script to use the new helpers for retrieving image tags and commit SHAs.
- Adds a new environment variable (COMMIT_SHA) to the app container, which is set to the short SHA of the deployed commit/tag.
- Ensures that the correct tag and commit SHA are used for both "edge" and versioned deployments.  APP_VERSION will be either 'edge' or the image tag.  Commit SHA is the corresponding GitHub commit SHA.


[AG-2015]: https://sagebionetworks.jira.com/browse/AG-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-1882]: https://sagebionetworks.jira.com/browse/AG-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ