### PR TITLE
feat(agora): bump DocumentDB from 5.0 to 8.0 (AG-1926)

### DIFF
--- a/src/docdb_stack.py
+++ b/src/docdb_stack.py
@@ -35,7 +35,7 @@ class DocdbStack(cdk.Stack):
         cluster_parameter_group = docdb.ClusterParameterGroup(
             self,
             "DocDbClusterParameterGroup",
-            family="docdb5.0",
+            family="docdb8.0",
             parameters={
                 "audit_logs": "disabled",
                 "profiler": "enabled",


### PR DESCRIPTION
## Description

Bump DocumentDB cluster parameter group from `docdb5.0` to `docdb8.0`.

## Related Issues

[AG-1926](https://sagebionetworks.jira.com/browse/AG-1926)

[AG-1926]: https://sagebionetworks.jira.com/browse/AG-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ