### PR TITLE
feat(agora): bump DocumentDB from 5.0 to 8.0 (AG-1926)

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,12 +89,16 @@ network_stack = NetworkStack(
     vpc_cidr=environment_variables["VPC_CIDR"],
 )
 
+# Existing DocumentDB 5.0 cluster as fallback during 8.0 migration
+# TODO: remove this stack after migration is complete
 docdb_props = DocdbProps(
     instance_type=ec2.InstanceType.of(
         ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE
     ),
     master_username=docdb_master_username,
     port=mongodb_port,
+    family="docdb5.0",
+    engine_version="5.0.0",
 )
 docdb_stack = DocdbStack(
     scope=cdk_app,
@@ -103,6 +107,26 @@ docdb_stack = DocdbStack(
     props=docdb_props,
 )
 docdb_stack.cluster.connections.allow_from(
+    ec2.Peer.ipv4(vpn_cidr), ec2.Port.all_traffic(), "Allow all VPN traffic"
+)
+
+# New DocumentDB 8.0 cluster
+docdb_v8_props = DocdbProps(
+    instance_type=ec2.InstanceType.of(
+        ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE
+    ),
+    master_username=docdb_master_username,
+    port=mongodb_port,
+    family="docdb8.0",
+    engine_version="8.0.0",
+)
+docdb_v8_stack = DocdbStack(
+    scope=cdk_app,
+    construct_id=f"{stack_name_prefix}-docdb-v8",
+    vpc=network_stack.vpc,
+    props=docdb_v8_props,
+)
+docdb_v8_stack.cluster.connections.allow_from(
     ec2.Peer.ipv4(vpn_cidr), ec2.Port.all_traffic(), "Allow all VPN traffic"
 )
 
@@ -133,11 +157,11 @@ api_props = ServiceProps(
         "MONGODB_PORT": f"{mongodb_port}",
         "MONGODB_NAME": "agora",
         "MONGODB_USER": docdb_master_username,
-        "MONGODB_HOST": docdb_stack.cluster.cluster_endpoint.hostname,
+        "MONGODB_HOST": docdb_v8_stack.cluster.cluster_endpoint.hostname,
     },
     container_secrets=[
         ServiceSecret(
-            secret_name=docdb_stack.master_password_secret.secret_name,
+            secret_name=docdb_v8_stack.master_password_secret.secret_name,
             environment_key="MONGODB_PASS",
         )
     ],
@@ -151,9 +175,9 @@ api_stack = ServiceStack(
     cluster=ecs_stack.cluster,
     props=api_props,
 )
-api_stack.add_dependency(docdb_stack)
+api_stack.add_dependency(docdb_v8_stack)
 api_stack.service.connections.allow_to_default_port(
-    docdb_stack.cluster,
+    docdb_v8_stack.cluster,
     "Allow API container to connect to DocumentDB cluster",
 )
 
@@ -164,7 +188,7 @@ api_next_props = ServiceProps(
     container_memory_reservation=2048,
     container_env_vars={
         "SERVER_PORT": "3334",
-        "SPRING_DATA_MONGODB_HOST": docdb_stack.cluster.cluster_endpoint.hostname,
+        "SPRING_DATA_MONGODB_HOST": docdb_v8_stack.cluster.cluster_endpoint.hostname,
         "SPRING_DATA_MONGODB_PORT": f"{mongodb_port}",
         "SPRING_DATA_MONGODB_DATABASE": "agora",
         "SPRING_DATA_MONGODB_USERNAME": docdb_master_username,
@@ -173,7 +197,7 @@ api_next_props = ServiceProps(
     },
     container_secrets=[
         ServiceSecret(
-            secret_name=docdb_stack.master_password_secret.secret_name,
+            secret_name=docdb_v8_stack.master_password_secret.secret_name,
             environment_key="SPRING_DATA_MONGODB_PASSWORD",
         )
     ],
@@ -187,9 +211,9 @@ api_next_stack = ServiceStack(
     cluster=ecs_stack.cluster,
     props=api_next_props,
 )
-api_next_stack.add_dependency(docdb_stack)
+api_next_stack.add_dependency(docdb_v8_stack)
 api_next_stack.service.connections.allow_to_default_port(
-    docdb_stack.cluster,
+    docdb_v8_stack.cluster,
     "Allow API Next container to connect to DocumentDB cluster",
 )
 
@@ -269,10 +293,10 @@ bastion_stack = BastionStack(
     props=bastion_props,
 )
 bastion_stack.instance.connections.allow_to(
-    docdb_stack.cluster,
+    docdb_v8_stack.cluster,
     ec2.Port.tcp_range(mongodb_port, 27030),
     "Allow bastion host to connect to DocumentDB cluster",
 )
-bastion_stack.add_dependency(docdb_stack)
+bastion_stack.add_dependency(docdb_v8_stack)
 
 cdk_app.synth()

--- a/src/docdb_props.py
+++ b/src/docdb_props.py
@@ -8,11 +8,20 @@ class DocdbProps:
     instance_type: What type of instance to start for the replicas
     master_username: The database admin account username
     port: The MongoDB port
+    family: The cluster parameter group family (e.g. "docdb8.0")
+    engine_version: The engine version (e.g. "8.0.0")
     """
 
     def __init__(
-        self, instance_type: ec2.InstanceType, master_username: str, port: int
+        self,
+        instance_type: ec2.InstanceType,
+        master_username: str,
+        port: int,
+        family: str,
+        engine_version: str,
     ) -> None:
         self.instance_type = instance_type
         self.master_username = master_username
         self.port = port
+        self.family = family
+        self.engine_version = engine_version

--- a/src/docdb_stack.py
+++ b/src/docdb_stack.py
@@ -35,7 +35,7 @@ class DocdbStack(cdk.Stack):
         cluster_parameter_group = docdb.ClusterParameterGroup(
             self,
             "DocDbClusterParameterGroup",
-            family="docdb5.0",
+            family=props.family,
             parameters={
                 "audit_logs": "disabled",
                 "profiler": "enabled",
@@ -55,6 +55,7 @@ class DocdbStack(cdk.Stack):
                 username=props.master_username,
                 password=self.master_password_secret.secret_value,
             ),
+            engine_version=props.engine_version,
             instance_type=props.instance_type,
             vpc=vpc,
             vpc_subnets=ec2.SubnetSelection(

--- a/tests/unit/test_docdb_stack.py
+++ b/tests/unit/test_docdb_stack.py
@@ -19,6 +19,8 @@ def test_docdb_created():
         ),
         master_username=master_username,
         port=port,
+        family="docdb8.0",
+        engine_version="8.0.0",
     )
     docdb_stack = DocdbStack(
         scope=cdk_app,
@@ -31,6 +33,7 @@ def test_docdb_created():
     template.has_resource_properties(
         "AWS::DocDB::DBClusterParameterGroup",
         {
+            "Family": "docdb8.0",
             "Parameters": {
                 "audit_logs": "disabled",
                 "profiler": "enabled",
@@ -39,12 +42,13 @@ def test_docdb_created():
                 "change_stream_log_retention_duration": "10800",
                 "tls": "disabled",
                 "ttl_monitor": "disabled",
-            }
+            },
         },
     )
     template.has_resource_properties(
         "AWS::DocDB::DBCluster",
         {
+            "EngineVersion": "8.0.0",
             "MasterUsername": master_username,
             "MasterUserPassword": assertions.Match.any_value(),
             "DBSubnetGroupName": assertions.Match.any_value(),


### PR DESCRIPTION
## Description

Per @zaro0508 suggested [here](https://github.com/Sage-Bionetworks-IT/modeladexplorer-infra/pull/32#discussion_r3101213013), this PR creates a new DocumentDB 8.0 cluster alongside the existing 5.0 cluster, and repoint dependency to the new 8.0 cluster. The old 5.0 cluster is kept as a rollback.

A follow-up PR will remove old 5.0 cluster after validation is done for new 8.0 cluster.


## Related Issues
[AG-1926](https://sagebionetworks.jira.com/browse/AG-1926)



[AG-1926]: https://sagebionetworks.jira.com/browse/AG-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ