### PR TITLE
chore(agora): remove DocumentDB 5.0 stack (AG-1926)

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,28 +89,7 @@ network_stack = NetworkStack(
     vpc_cidr=environment_variables["VPC_CIDR"],
 )
 
-# Existing DocumentDB 5.0 cluster as fallback during 8.0 migration
-# TODO: remove this stack after migration is complete
-docdb_props = DocdbProps(
-    instance_type=ec2.InstanceType.of(
-        ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE
-    ),
-    master_username=docdb_master_username,
-    port=mongodb_port,
-    family="docdb5.0",
-    engine_version="5.0.0",
-)
-docdb_stack = DocdbStack(
-    scope=cdk_app,
-    construct_id=f"{stack_name_prefix}-docdb",
-    vpc=network_stack.vpc,
-    props=docdb_props,
-)
-docdb_stack.cluster.connections.allow_from(
-    ec2.Peer.ipv4(vpn_cidr), ec2.Port.all_traffic(), "Allow all VPN traffic"
-)
-
-# New DocumentDB 8.0 cluster
+# DocumentDB 8.0 cluster
 docdb_v8_props = DocdbProps(
     instance_type=ec2.InstanceType.of(
         ec2.InstanceClass.MEMORY5, ec2.InstanceSize.LARGE


### PR DESCRIPTION
## Description

Follow-up to #83. Removes the old DocumentDB 5.0 stack (`agora-dev-docdb`) from the CDK app so CI auto-deploy can complete successfully.

## Background

On merge of #83, [CI](https://github.com/Sage-Bionetworks-IT/agora-infra-v3/actions/runs/24841540418) auto-deploy to dev failed:
```
agora-dev-docdb | UPDATE_ROLLBACK_IN_PROGRESS | AWS::CloudFormation::Stack | agora-dev-docdb
Delete canceled. Cannot delete export agora-dev-docdb:ExportsOutputFnGetAttDocDbClusterSecurityGroupD0D4993EGroupIdE6B2D518
as it is in use by agora-dev-api, agora-dev-api-next and agora-dev-bastion.
```

CDK dropped the old stack's exports, but the deployed services still import them - and CloudFormation rejects removing an in-use export. Since deployment pipeline stops at failure, the services never got to update (which would drop the imports), so they're still on 5.0. Removing the old stack from the CDK app stops CloudFormation from ever touching it. The service stacks then deploy cleanly, drop their imports, and repoint to 8.0. The old stack stays in AWS untouched as a fallback and can be deleted manually afterwards.

## Related Issues
[AG-1926](https://sagebionetworks.jira.com/browse/AG-1926)

[AG-1926]: https://sagebionetworks.jira.com/browse/AG-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ