### PR TITLE
feat(agora): align GitHub hardening changes with Model-AD (AG-2095)

### DIFF
--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -3,7 +3,7 @@ name: aws-deploy
 
 # Ensures that only one deploy task per branch/environment will run at a time.
 concurrency:
-  group: ${{ inputs.environment }}
+  group: ${{ inputs.aws-environment }}
   cancel-in-progress: false
 
 on:
@@ -21,7 +21,7 @@ on:
       role-duration-seconds:
         type: number
         default: 3600
-      environment:
+      aws-environment:
         required: true
         type: string
 
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   deploy:
+    environment: ${{ inputs.aws-environment }}
     permissions:
       id-token: write
       contents: read
@@ -38,7 +39,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ inputs.environment }}
+          ref: ${{ inputs.aws-environment }}
       - name: Install AWS CLI
         run: sudo snap install aws-cli --classic
       - name: Install AWS CDK CLI
@@ -60,5 +61,5 @@ jobs:
       - name: CDK deploy
         run: uv run cdk deploy --all --debug --concurrency 5 --require-approval never
         env:
-          ENV: ${{ inputs.environment }}
+          ENV: ${{ inputs.aws-environment }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/aws-deploy.yaml
+++ b/.github/workflows/aws-deploy.yaml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.environment }}
       - name: Install AWS CLI
         run: sudo snap install aws-cli --classic
       - name: Install AWS CDK CLI

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -12,8 +12,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: dev  # AWS account / env name
-      ref: dev          # git branch to check out (matches env by convention)
+      aws-environment: dev
+      ref: dev  # git branch to check out
   aws-deploy:
     needs: test
     permissions:
@@ -23,4 +23,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::607346494281:role/sagebase-github-oidc-agora-infra-v3"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: dev
+      aws-environment: dev

--- a/.github/workflows/deploy-dev.yaml
+++ b/.github/workflows/deploy-dev.yaml
@@ -12,7 +12,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: dev
+      environment: dev  # AWS account / env name
+      ref: dev          # git branch to check out (matches env by convention)
   aws-deploy:
     needs: test
     permissions:

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -11,8 +11,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: prod  # AWS account / env name
-      ref: prod          # git branch to check out (matches env by convention)
+      aws-environment: prod
+      ref: prod  # git branch to check out
   aws-deploy:
     needs: test
     permissions:
@@ -22,4 +22,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-agora-infra-v3"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: prod
+      aws-environment: prod

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -11,7 +11,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: prod
+      environment: prod  # AWS account / env name
+      ref: prod          # git branch to check out (matches env by convention)
   aws-deploy:
     needs: test
     permissions:

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -11,8 +11,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: stage  # AWS account / env name
-      ref: stage          # git branch to check out (matches env by convention)
+      aws-environment: stage
+      ref: stage  # git branch to check out
   aws-deploy:
     needs: test
     permissions:
@@ -22,4 +22,4 @@ jobs:
     with:
       role-to-assume: "arn:aws:iam::681175625864:role/sagebase-github-oidc-agora-infra-v3"
       role-session-name: ${{ github.repository_owner }}-${{ github.event.repository.name }}-${{ github.run_id }}
-      environment: stage
+      aws-environment: stage

--- a/.github/workflows/deploy-stage.yaml
+++ b/.github/workflows/deploy-stage.yaml
@@ -11,7 +11,8 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: stage
+      environment: stage  # AWS account / env name
+      ref: stage          # git branch to check out (matches env by convention)
   aws-deploy:
     needs: test
     permissions:

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -11,5 +11,5 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: dev  # AWS account / env name
+      aws-environment: dev
       # ref intentionally omitted: defaults to '' so checkout uses the PR head

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -11,4 +11,5 @@ jobs:
   test:
     uses: ./.github/workflows/test.yaml
     with:
-      environment: dev
+      environment: dev  # AWS account / env name
+      # ref intentionally omitted: defaults to '' so checkout uses the PR head

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,13 +16,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set up uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+      - name: Run uv-audit hook
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
-          version: "0.11.7"
-          checksum: "6681d691eb7f9c00ac6a3af54252f7ab29ae72f0c8f95bdc7f9d1401c23ea868"
-      - name: Audit dependencies
-        run: uv audit
+          extra_args: uv-audit --all-files
   unit-tests:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
       environment:
         required: true
         type: string
+      ref:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: read
@@ -16,8 +20,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Set up Python
         uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version-file: pyproject.toml
       - name: Run uv-audit hook
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
         with:
@@ -27,6 +35,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Set up uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -41,6 +51,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.ref }}
       - name: Install AWS CDK CLI
         run: npm install -g aws-cdk@2.1007.0 --ignore-scripts
       - name: Set up uv

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,9 +3,14 @@ name: test
 on:
   workflow_call:
     inputs:
-      environment:
+      # aws-environment accepts one of three values:
+      #   'dev' / 'stage' / 'prod' - the AWS deployment target
+      aws-environment:
         required: true
         type: string
+      # ref accepts one of four values:
+      #   'dev' / 'stage' / 'prod' - pin checkout to that env branch  (deploy-*.yaml)
+      #   ''                       - check out the PR's commit        (pr-check.yaml; ref omitted)
       ref:
         required: false
         type: string
@@ -64,6 +69,6 @@ jobs:
         run: uv sync --frozen --no-group dev
       - name: Generate cloudformation
         env:
-          ENV: ${{ inputs.environment }}
+          ENV: ${{ inputs.aws-environment }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: uv run cdk synth --debug --output ./cdk.out

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,26 +1,29 @@
 ci:
   autoupdate_schedule: monthly
+  # uv-audit queries api.osv.dev for CVEs. pre-commit.ci blocks outbound
+  # network during hook execution, so the GHA audit job in test.yaml runs it instead.
+  skip: [uv-audit]
 
 default_language_version:
   python: python3
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b # v5.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
     hooks:
       - id: end-of-file-fixer
       - id: mixed-line-ending
       - id: trailing-whitespace
   - repo: https://github.com/PyCQA/flake8
-    rev: cf1542cefa3e766670b2066dd75c4571d682a649 # 7.1.1
+    rev: d93590f5be797aabb60e3b09f2f52dddb02f349f # 7.3.0
     hooks:
       - id: flake8
   - repo: https://github.com/adrienverge/yamllint
-    rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6 # v1.35.1
+    rev: cba56bcde1fdd01c1deb3f945e69764c291a6530 # v1.38.0
     hooks:
       - id: yamllint
   - repo: https://github.com/awslabs/cfn-python-lint
-    rev: f5084b0c87696260c4ccfcc77105a203a4679143 # v1.22.3
+    rev: 9823e89806e500c98f3ddb6efbe454a840b27136 # v1.50.1
     hooks:
       - id: cfn-python-lint
         args:
@@ -34,16 +37,20 @@ repos:
             ^.github/|
             ^.pre-commit-config.yaml
           )
-  - repo: https://github.com/psf/black
-    rev: 1b2427a2b785cc4aac97c19bb4b9a0de063f9547 # 24.10.0
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: fa505ab9c3e0fedafe1709fd7ac2b5f8996c670d # 26.3.1
     hooks:
       - id: black
   - repo: https://github.com/astral-sh/uv-pre-commit
     rev: 6a280ba12b7901e47757c868c8c13c6a624c9ecb # 0.11.7
     hooks:
       - id: uv-lock
+      # Runs locally when uv.lock, pyproject.toml, or uv.toml are part of
+      # the commit, and on every PR via the GHA audit job in test.yaml.
+      # Skipped on pre-commit.ci (see ci.skip comment above).
+      - id: uv-audit
   - repo: https://github.com/sirosen/check-jsonschema
-    rev: 9932a7df36a32ef5e79dfd5df26ad89ca15bfa61 # 0.30.0
+    rev: 943377262562a12b57292fc98fabd7dbf81451fe # 0.37.2
     hooks:
       - id: check-github-workflows
       - id: check-github-actions

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All the development tools are provided when developing inside the dev container
 also include a Python virtual environment where all the Python packages needed
 are already installed.
 
-If you decide the develop outside of the dev container, you'll need
+If you decide to develop outside of the dev container, you'll need
 [uv](https://docs.astral.sh/uv/getting-started/installation/) installed.
 Then run:
 

--- a/uv.lock
+++ b/uv.lock
@@ -475,11 +475,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

| Area | Resolution |
| --- | --- |
| **Test/deploy ref asymmetry** | `test.yaml` gained an optional `ref` input; the three `deploy-*.yaml` callers pin it to their env branch; `pr-check.yaml` omits it so the PR head is tested. Inline comments at each call site explain the duality between `environment` (AWS account) and `ref` (git branch). |
| **Unpinned Python in `audit` job** | `setup-python` now reads from `pyproject.toml` via `python-version-file`. |
| **Major hook bumps** | Black 26.3.1 and cfn-lint 1.50.1 produce zero diffs against the current repo — no pre-formatting needed. The new `uv-audit` hook surfaced two `urllib3` CVEs; bumped to 2.7.0 in `uv.lock` (only `urllib3` changed). |
| **Address `environment` ambiguity** | Rename `environment` to `aws-environment` to avoid ambiguity |

## Why `test.yaml` gained a `ref` input

A manual "Run workflow" in the GitHub Actions UI lets the user pick any
branch from a dropdown, and whatever they pick is what every checkout
step in the run uses by default. `aws-deploy.yaml` pins its own checkout
to the env branch (`dev`/`stage`/`prod`); if `test.yaml` stayed unpinned,
the jobs there would run against the dispatcher's picked branch while
`aws-deploy.yaml` deployed a different one. The `needs: test` gate in
the `deploy-*` workflows would then guard the wrong code — failing jobs
on an unrelated branch could block a valid redeploy, and (worse) passing
jobs on an unrelated branch could let broken env-branch code reach AWS.

### Malicious-actor scenario (attacker with repo write access)

The env branch contains broken or unauthorized code whose jobs in
`test.yaml` would fail. Normally that blocks the deploy. Without the
`ref` pin, the attacker dispatches `deploy-dev` and picks any branch
whose jobs they know pass, satisfying `needs: test` — and
`aws-deploy.yaml` deploys the env branch's broken tip anyway. Pinning
`ref` to the env branch forces the gate to validate the same code that
will deploy.

### How callers use the new input

| Caller | Passes | Effect |
| --- | --- | --- |
| `deploy-dev.yaml` | `ref: dev` | Audit/unit-tests/synth run against `dev` regardless of dispatcher's dropdown choice |
| `deploy-stage.yaml` | `ref: stage` | Same, pinned to `stage` |
| `deploy-prod.yaml` | `ref: prod` | Same, pinned to `prod` |
| `pr-check.yaml` | (omitted) | Empty default lets `actions/checkout` fall back to the PR head — correct for PR validation |

## Other changes bundled with this hardening PR

- **`python-version-file: pyproject.toml`** added to the `audit` job's
  `setup-python` step. Without it, the runner's preinstalled Python is used,
  which drifts silently as GitHub upgrades the `ubuntu-latest` image. Reading
  the version from `pyproject.toml` keeps the workflow tracking the project's
  declared `requires-python`.
- **`urllib3` bumped 2.6.3 → 2.7.0 in `uv.lock`.** The newly enabled `uv-audit`
  hook caught two advisories on 2.6.3 (GHSA-mf9v-mfxr-j63j, GHSA-qccp-gfcp-xxvc),
  both fixed in 2.7.0. Done via `uv lock --upgrade-package urllib3` — only
  urllib3 changed in the lockfile.

## Disambiguating `environment` → `aws-environment`

The workflow input named `environment` collided with GitHub Actions'
reserved job-level `environment:` key (used to bind a job to a GitHub
Environment for protection rules and named-reviewer approval). With
the new binding added in this PR, the line in `aws-deploy.yaml` would
have read `environment: ${{ inputs.environment }}` — the same word in
three different roles on one line. Renaming the input to
`aws-environment` makes the binding line read unambiguously:

```yaml
environment: ${{ inputs.aws-environment }}
```

The rename touched six files: `aws-deploy.yaml`, `test.yaml`, the
three `deploy-*.yaml` callers, and `pr-check.yaml`.

## Post-merge environment configuration

Environment protection rules will be configured post-merge.

## Issue

[AG-2095](https://sagebionetworks.jira.com/browse/AG-2095)





[AG-2095]: https://sagebionetworks.jira.com/browse/AG-2095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ