### PR TITLE
revert to version deployed to prod to prepare for deploying new bastion to stage/prod (IT-5079)

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ match environment:
             "CERTIFICATE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "AMP-AD DCC / 101500", "Environment": "prod"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
-            "GHCR_PACKAGE_VERSION": "4.2.1-rc1",
+            "GHCR_PACKAGE_VERSION": "4.2.0-rc2",
         }
     case "stage":
         environment_variables = {
@@ -34,7 +34,7 @@ match environment:
             "CERTIFICATE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "AMP-AD DCC / 101500", "Environment": "stage"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
-            "GHCR_PACKAGE_VERSION": "4.2.1-rc1",
+            "GHCR_PACKAGE_VERSION": "4.2.0-rc2",
         }
     case "dev":
         environment_variables = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "constructs==10.3.0",
     "boto3==1.34.113",
     "requests==2.33.0",
+    "idna==3.15",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,7 @@ dependencies = [
     { name = "aws-cdk-lib" },
     { name = "boto3" },
     { name = "constructs" },
+    { name = "idna" },
     { name = "requests" },
 ]
 
@@ -24,6 +25,7 @@ requires-dist = [
     { name = "aws-cdk-lib", specifier = "==2.189.1" },
     { name = "boto3", specifier = "==1.34.113" },
     { name = "constructs", specifier = "==10.3.0" },
+    { name = "idna", specifier = "==3.15" },
     { name = "requests", specifier = "==2.33.0" },
 ]
 
@@ -238,11 +240,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.12"
+version = "3.15"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/22/12/2948fbe5513d062169bd91f7d7b1cd97bc8894f32946b71fa39f6e63ca0c/idna-3.12.tar.gz", hash = "sha256:724e9952cc9e2bd7550ea784adb098d837ab5267ef67a1ab9cf7846bdbdd8254", size = 194350, upload-time = "2026-04-21T13:32:48.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl", hash = "sha256:60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67", size = 68634, upload-time = "2026-04-21T13:32:47.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We are planning to delete and redeploy the bastion for stage and prod (see [IT-5079](https://sagebionetworks.jira.com/browse/IT-5079)). First, we need to revert the stage and prod version to the last released app version, so that: 
1. the app version on prod is not updated on deploy to prod
2. after merging these changes to stage, we can delete the stage bastion and rerun the deploy-stage job to evaluate which services are redeployed. We expect that only the bastion will be recreated, but if other services are also updated, then we will need to schedule downtime for the prod deployment 

[IT-5079]: https://sagebionetworks.jira.com/browse/IT-5079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ