### PR TITLE
fix(agora): set ENVIRONMENT env var and scope GTM container to prod only (AG-2104)

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,8 @@ match environment:
             "TAGS": {"CostCenter": "AMP-AD DCC / 101500", "Environment": "prod"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "4.2.0-rc2",
+            "GTM_ENABLED": "true",
+            "GTM_CONTAINER_ID": "GTM-WHXXVWKC",
         }
     case "stage":
         environment_variables = {
@@ -35,6 +37,8 @@ match environment:
             "TAGS": {"CostCenter": "AMP-AD DCC / 101500", "Environment": "stage"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
             "GHCR_PACKAGE_VERSION": "4.2.0-rc2",
+            "GTM_ENABLED": "false",
+            "GTM_CONTAINER_ID": "",
         }
     case "dev":
         environment_variables = {
@@ -44,6 +48,8 @@ match environment:
             "TAGS": {"CostCenter": "AMP-AD DCC / 101500", "Environment": "dev"},
             "AUTO_SCALE_CAPACITY": {"min": 1, "max": 2},
             "GHCR_PACKAGE_VERSION": "edge",
+            "GTM_ENABLED": "false",
+            "GTM_CONTAINER_ID": "",
         }
     case _:
         valid_envs_str = ",".join(VALID_ENVIRONMENTS)
@@ -207,7 +213,9 @@ app_props = ServiceProps(
         "CSR_API_URL": f"https://{fully_qualified_domain_name}/api/v1",
         # TODO: update this port when agora-api is removed from this stack
         "SSR_API_URL": "http://agora-api:3333/v1",
-        "GOOGLE_TAG_MANAGER_ID": "GTM-WHXXVWKC",
+        "ENVIRONMENT": environment,
+        "GOOGLE_TAG_MANAGER_ENABLED": environment_variables["GTM_ENABLED"],
+        "GOOGLE_TAG_MANAGER_ID": environment_variables["GTM_CONTAINER_ID"],
         "SENTRY_ENVIRONMENT": environment,
         "SENTRY_RELEASE": f"agora@{ghcr_package_version}+{short_commit_sha}",
     },


### PR DESCRIPTION
## Description

The Agora CDK app hardcodes `GOOGLE_TAG_MANAGER_ID` for all environments (mixing dev/stage traffic into prod analytics) and doesn't set `ENVIRONMENT` on the app container (which will cause a GA4 outage once Agora adopts the new config library). This PR adds the `ENVIRONMENT` variable so the config loader picks the correct profile, and parameterizes GTM per environment so only prod fires analytics.

## Related Issue

- [AG-2104](https://sagebionetworks.jira.com/browse/AG-2104)

## Changelog

- Set `ENVIRONMENT` on the app container so the SSR config loader resolves the correct profile per env
- Move `GOOGLE_TAG_MANAGER_ID` and `GOOGLE_TAG_MANAGER_ENABLED` into the per-env `environment_variables` block in `app.py`
- Enable Google Tag Manager only on prod (container `GTM-WHXXVWKC`); disable on dev and stage

[AG-2104]: https://sagebionetworks.jira.com/browse/AG-2104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ