### PR TITLE
AG-2165: point stage/prod configs to 4.3.0-rc1

### DIFF
--- a/app.py
+++ b/app.py
@@ -25,7 +25,7 @@ match environment:
             "CERTIFICATE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "AMP-AD DCC / 101500", "Environment": "prod"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
-            "GHCR_PACKAGE_VERSION": "4.2.0-rc2",
+            "GHCR_PACKAGE_VERSION": "4.3.0-rc1",
             "GTM_ENABLED": "true",
             "GTM_CONTAINER_ID": "GTM-WHXXVWKC",
         }
@@ -36,7 +36,7 @@ match environment:
             "CERTIFICATE_ID": "69b3ba97-b382-4648-8f94-a250b77b4994",
             "TAGS": {"CostCenter": "AMP-AD DCC / 101500", "Environment": "stage"},
             "AUTO_SCALE_CAPACITY": {"min": 2, "max": 4},
-            "GHCR_PACKAGE_VERSION": "4.2.0-rc2",
+            "GHCR_PACKAGE_VERSION": "4.3.0-rc1",
             "GTM_ENABLED": "false",
             "GTM_CONTAINER_ID": "",
         }


### PR DESCRIPTION
[AG-2165](https://sagebionetworks.jira.com/browse/AG-2165): point stage/prod configs to 4.3.0-rc1, to prepare for promoting 4.3.0-rc1 to stage.

[AG-2165]: https://sagebionetworks.jira.com/browse/AG-2165?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ